### PR TITLE
Fix zero-datetime decoding

### DIFF
--- a/lib/myxql/protocol/values.ex
+++ b/lib/myxql/protocol/values.ex
@@ -452,6 +452,17 @@ defmodule MyXQL.Protocol.Values do
     decode_binary_row(r, null_bitmap >>> 1, t, [v | acc])
   end
 
+  defp decode_datetime(
+         <<0, r::bits>>,
+         null_bitmap,
+         t,
+         acc,
+         type
+       ) do
+    v = new_datetime(type, 0, 0, 0, 0, 0, 0, {0, 0})
+    decode_binary_row(r, null_bitmap >>> 1, t, [v | acc])
+  end
+
   defp new_datetime(:datetime, year, month, day, hour, minute, second, microsecond) do
     %DateTime{
       year: year,

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -100,6 +100,10 @@ defmodule MyXQL.Protocol.ValueTest do
         assert_roundtrip(c, "my_date", ~D[1999-12-31])
       end
 
+      test "MYSQL_TYPE_DATE - Zero date", c do
+        assert_roundtrip(c, "my_date", ~D[0000-00-00])
+      end
+
       test "MYSQL_TYPE_TIME", c do
         assert_roundtrip(c, "my_time", ~T[09:10:20])
         assert insert_and_get(c, "my_time", ~T[09:10:20.123]) == ~T[09:10:20]
@@ -134,6 +138,10 @@ defmodule MyXQL.Protocol.ValueTest do
         assert insert_and_get(c, "my_datetime", datetime) == ndt
       end
 
+      test "MYSQL_TYPE_DATETIME - Zero datetime", c do
+        assert_roundtrip(c, "my_datetime", ~N[0000-00-00 00:00:00])
+      end
+
       if @protocol == :binary do
         test "MYSQL_TYPE_DATETIME - non-UTC datetimes", c do
           ndt = ~N[1999-12-31 09:10:20]
@@ -147,6 +155,10 @@ defmodule MyXQL.Protocol.ValueTest do
 
       test "MYSQL_TYPE_TIMESTAMP", c do
         assert_roundtrip(c, "my_timestamp", ~U[1999-12-31 09:10:20Z])
+      end
+
+      test "MYSQL_TYPE_TIMESTAMP - Zero timestamp", c do
+        assert_roundtrip(c, "my_timestamp", ~U[0000-00-00 00:00:00Z])
       end
 
       test "MYSQL_TYPE_TIMESTAMP - time zones", c do


### PR DESCRIPTION
According to https://dev.mysql.com/doc/internals/en/binary-protocol-value.html#packet-ProtocolBinary::MYSQL_TYPE_DATETIME
and https://dev.mysql.com/doc/refman/8.0/en/datetime.html

`length (1) -- number of bytes following (valid values: 0, 4, 7, 11)`

`Invalid DATE, DATETIME, or TIMESTAMP values are converted to the “zero” value of the appropriate type ('0000-00-00' or '0000-00-00 00:00:00'). `