### PR TITLE
Zero-datetime decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ bit             <<1::size(1), 0::size(1)>>
 
 \* See [Decimal](https://github.com/ericmj/decimal)
 
-\*\* datetime fields are represented as `NaiveDateTime`, however a UTC `DateTime` can be used for encoding as well
+\*\* datetime fields are represented as `NaiveDateTime`, however a UTC `DateTime` can be used for encoding as well. Also when not using sql strict mode, zero dates and datetimes ("0000-00-00") will be returned as atoms (`:zero_date`, `:zero_datetime`).
 
 ## JSON support
 

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -20,7 +20,6 @@ defmodule MyXQL.Protocol.ValueTest do
         query!(c, "SELECT TIMESTAMP '0000-00-00 00:00:00'")
       end
 
-
       test "MYSQL_TYPE_DATE - Zero date", c do
         query!(c, "SELECT DATE '0000-00-00'")
       end
@@ -311,6 +310,7 @@ defmodule MyXQL.Protocol.ValueTest do
 
   defp connect(c) do
     sql_mode = Keyword.get(c, :sql_mode, "STRICT_TRANS_TABLES")
+
     after_connect = fn conn ->
       MyXQL.query!(conn, "SET SESSION sql_mode = '#{sql_mode}'")
     end

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -1,6 +1,7 @@
 defmodule MyXQL.Protocol.ValueTest do
   use ExUnit.Case, async: true
   use Bitwise
+  @default_mode "STRICT_TRANS_TABLES"
 
   unless macro_exported?(Kernel, :sigil_U, 2) do
     defmacrop sigil_U({:<<>>, _, [string]}, _) do
@@ -11,23 +12,10 @@ defmodule MyXQL.Protocol.ValueTest do
   for protocol <- [:text, :binary] do
     @protocol protocol
 
-    describe "#{@protocol} protocol - empty mode" do
-      setup do
-        connect(protocol: @protocol, sql_mode: "")
-      end
-
-      test "MYSQL_TYPE_TIMESTAMP - Zero timestamp", c do
-        query!(c, "SELECT TIMESTAMP '0000-00-00 00:00:00'")
-      end
-
-      test "MYSQL_TYPE_DATE - Zero date", c do
-        query!(c, "SELECT DATE '0000-00-00'")
-      end
-    end
-
-    describe "#{@protocol} protocol - strict mode" do
-      setup do
-        connect(protocol: @protocol)
+    describe "#{@protocol} protocol" do
+      setup context do
+        mode = Map.get(context, :mode, @default_mode)
+        connect(protocol: @protocol, mode: mode)
       end
 
       test "MYSQL_TYPE_TINY", c do
@@ -129,6 +117,16 @@ defmodule MyXQL.Protocol.ValueTest do
 
         assert insert_and_get(c, "my_datetime", ~N[1999-12-31 09:10:20.123]) ==
                  ~N[1999-12-31 09:10:20]
+      end
+
+      @tag mode: "ALLOW_INVALID_DATES"
+      test "MYSQL_TYPE_TIMESTAMP - Zero timestamp", c do
+        assert query!(c, "SELECT TIMESTAMP '0000-00-00 00:00:00'").rows == [[:zero_datetime]]
+      end
+
+      @tag mode: "ALLOW_INVALID_DATES"
+      test "MYSQL_TYPE_DATE - Zero date", c do
+        assert query!(c, "SELECT DATE '0000-00-00'").rows == [[:zero_date]]
       end
 
       @tag timestamp_precision: true
@@ -309,10 +307,9 @@ defmodule MyXQL.Protocol.ValueTest do
   end
 
   defp connect(c) do
-    sql_mode = Keyword.get(c, :sql_mode, "STRICT_TRANS_TABLES")
-
     after_connect = fn conn ->
-      MyXQL.query!(conn, "SET SESSION sql_mode = '#{sql_mode}'")
+      mode = Keyword.get(c, :mode, @default_mode)
+      MyXQL.query!(conn, "SET SESSION sql_mode = '#{mode}'")
     end
 
     {:ok, conn} = MyXQL.start_link([after_connect: after_connect] ++ TestHelper.opts())

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -11,7 +11,22 @@ defmodule MyXQL.Protocol.ValueTest do
   for protocol <- [:text, :binary] do
     @protocol protocol
 
-    describe "#{@protocol} protocol" do
+    describe "#{@protocol} protocol - empty mode" do
+      setup do
+        connect(protocol: @protocol, sql_mode: "")
+      end
+
+      test "MYSQL_TYPE_TIMESTAMP - Zero timestamp", c do
+        query!(c, "SELECT TIMESTAMP '0000-00-00 00:00:00'")
+      end
+
+
+      test "MYSQL_TYPE_DATE - Zero date", c do
+        query!(c, "SELECT DATE '0000-00-00'")
+      end
+    end
+
+    describe "#{@protocol} protocol - strict mode" do
       setup do
         connect(protocol: @protocol)
       end
@@ -295,8 +310,9 @@ defmodule MyXQL.Protocol.ValueTest do
   end
 
   defp connect(c) do
+    sql_mode = Keyword.get(c, :sql_mode, "STRICT_TRANS_TABLES")
     after_connect = fn conn ->
-      MyXQL.query!(conn, "SET SESSION sql_mode = 'STRICT_TRANS_TABLES'")
+      MyXQL.query!(conn, "SET SESSION sql_mode = '#{sql_mode}'")
     end
 
     {:ok, conn} = MyXQL.start_link([after_connect: after_connect] ++ TestHelper.opts())


### PR DESCRIPTION
For mysql it is possible to use zero dates and datetimes if the
sql_mode is not set to strict.

https://dev.mysql.com/doc/refman/8.0/en/datetime.html

If we raise then the full query to sql will fail and the user will not
be able to retreive anything.

It should be up to the user to decide how to handle datetime columns
when not in strict mode.

Solves #65 