### PR TITLE
clarify note about SSL connection requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Documentation: <http://hexdocs.pm/myxql>
   * Supports `mysql_native_password`, `sha256_password` (\*), and `caching_sha256_password` (\*)
     authentication plugins
 
-\* Requires either SSL connection or the server must exchange its public key during handshake.
+\* These authentication methods require either an SSL connection or the server must exchange its public key during handshake.
 
 ## Usage
 


### PR DESCRIPTION
Got confused initially by the "requires ... SSL connection" note -- my brain parsed it as another bullet point (that for some reason failed to be displayed as a proper bullet point as the ones above it), and so initially I thought that myxql requires a secure connection always.

I think it's not too far-fetched that others might parse the note similarly, so I'm suggesting to clarify it so no misunderstandings will occur from that.