### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Documentation: <http://hexdocs.pm/myxql>
   * Automatic decoding and encoding of Elixir values to and from MySQL text and binary protocols
   * Supports transactions, prepared queries, streaming, pooling and more via [DBConnection](https://github.com/elixir-ecto/db_connection)
   * Supports MySQL 5.5+, 8.0, and MariaDB 10.3
-  * Supports `mysql_native_password`, `sha256_password` (\*), and `caching_sha256_password` (\*)
+  * Supports `mysql_native_password`, `sha256_password` (\*), and `caching_sha2_password` (\*)
     authentication plugins
 
 \* These authentication methods require either an SSL connection or the server must exchange its public key during handshake.


### PR DESCRIPTION
Reference to the authentication plugin has a typo.