### PR TITLE
Support receiving packets larger than 16MB

### DIFF
--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -194,7 +194,7 @@ defmodule MyXQL.Client do
          client,
          partial
        )
-       when size != @default_max_packet_size do
+       when size < @default_max_packet_size do
     case decoder.(<<partial::binary, payload::binary>>, rest, decoder_state) do
       {:cont, decoder_state} ->
         recv_packets(rest, decoder, decoder_state, timeout, client)

--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -217,7 +217,7 @@ defmodule MyXQL.Client do
          client,
          partial
        )
-       when size == @default_max_packet_size do
+       when size >= @default_max_packet_size do
     recv_packets(
       rest,
       decoder,

--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -184,14 +184,18 @@ defmodule MyXQL.Client do
 
   ## Internals
 
+  defp recv_packets(data, decode, decoder_state, timeout, client, partial \\ <<>>)
+
   defp recv_packets(
          <<size::uint3, _seq::uint1, payload::string(size), rest::binary>>,
          decoder,
          decoder_state,
          timeout,
-         client
-       ) do
-    case decoder.(payload, rest, decoder_state) do
+         client,
+         partial
+       )
+       when size != @default_max_packet_size do
+    case decoder.(<<partial::binary, payload::binary>>, rest, decoder_state) do
       {:cont, decoder_state} ->
         recv_packets(rest, decoder, decoder_state, timeout, client)
 
@@ -203,11 +207,39 @@ defmodule MyXQL.Client do
     end
   end
 
+  # If the packet size equals max packet size, save the payload, receive
+  # more data and try again
+  defp recv_packets(
+         <<size::uint3, _seq::uint1, payload::string(size), rest::binary>>,
+         decoder,
+         decoder_state,
+         timeout,
+         client,
+         partial
+       )
+       when size == @default_max_packet_size do
+    recv_packets(
+      rest,
+      decoder,
+      decoder_state,
+      timeout,
+      client,
+      <<partial::binary, payload::binary>>
+    )
+  end
+
   # If we didn't match on a full packet, receive more data and try again
-  defp recv_packets(rest, decoder, decoder_state, timeout, client) do
+  defp recv_packets(rest, decoder, decoder_state, timeout, client, partial) do
     case recv_data(client, timeout) do
       {:ok, data} ->
-        recv_packets(<<rest::binary, data::binary>>, decoder, decoder_state, timeout, client)
+        recv_packets(
+          <<rest::binary, data::binary>>,
+          decoder,
+          decoder_state,
+          timeout,
+          client,
+          partial
+        )
 
       {:error, _} = error ->
         error

--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -28,7 +28,7 @@ defmodule MyXQL.Protocol do
 
   defp encode_packet(payload, payload_size, sequence_id, max_packet_size) do
     if payload_size > max_packet_size do
-      <<new_payload::size(max_packet_size)-binary, rest::binary>> = payload
+      <<new_payload::size(max_packet_size)-binary, rest::binary>> = IO.iodata_to_binary(payload)
       rest_size = payload_size - max_packet_size
       next_sequence_id = if sequence_id < 255, do: sequence_id + 1, else: 0
 

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -241,6 +241,16 @@ defmodule MyXQL.Protocol.ValueTest do
         assert_roundtrip(c, "my_longblob", blob)
       end
 
+      test "MYSQL_TYPE_LONG_BLOB in payload equal to max packet size", c do
+        blob = String.duplicate("a", 16_777_209)
+        assert_roundtrip(c, "my_longblob", blob)
+      end
+
+      test "MYSQL_TYPE_LONG_BLOB in payload above max packet size", c do
+        blob = String.duplicate("a", 16_777_209 + 100_000)
+        assert_roundtrip(c, "my_longblob", blob)
+      end
+
       test "MYSQL_TYPE_VAR_STRING - SQL VARBINARY", c do
         assert_roundtrip(c, "my_varbinary3", <<1, 2, 3>>)
       end


### PR DESCRIPTION
Closes #10 

This approach assumes that there's always more data to receive if the current packet's payload size is exactly equal to max packet size (16MB) - which is in agreement with specification at https://dev.mysql.com/doc/internals/en/sending-more-than-16mbyte.html. The tests seem to confirm that (when working on the change, I've sprinkled IO.inspects when running the tests to see which `recv_packets` clauses are called for various payload sizes, including exact multiples of max packet size; also, when adjusting the test to make the payload fix exactly at max packet size, the next successful data fetch returns a payload with size 0).