### PR TITLE
Require :ssl & :public_key applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,22 +15,18 @@ defmodule MyXQL.MixProject do
       source_url: @source_url,
       package: package(),
       docs: docs(),
-      deps: deps(),
-      xref: [exclude: [:ssl, :public_key]]
+      deps: deps()
     ]
   end
 
   def application() do
     [
-      extra_applications: extra_applications(Mix.env()),
+      extra_applications: [:ssl, :public_key],
       env: [
         json_library: Jason
       ]
     ]
   end
-
-  defp extra_applications(env) when env in [:dev, :test], do: [:ssl | extra_applications(:prod)]
-  defp extra_applications(_), do: [:logger, :crypto]
 
   defp package() do
     [

--- a/test/myxql/sync_test.exs
+++ b/test/myxql/sync_test.exs
@@ -72,18 +72,4 @@ defmodule MyXQL.SyncTest do
     [%{"Value" => count}] = TestHelper.mysql!("show global status like 'Prepared_stmt_count'")
     String.to_integer(count)
   end
-
-  @tag capture_log: true
-  test "connect with SSL but without starting :ssl" do
-    Application.stop(:ssl)
-
-    assert_raise RuntimeError,
-                 ~r"cannot be established because `:ssl` application is not started",
-                 fn ->
-                   opts = [ssl: true] ++ @opts
-                   MyXQL.start_link(opts)
-                 end
-  after
-    Application.ensure_all_started(:ssl)
-  end
 end


### PR DESCRIPTION
Previously we had some extra code inspired by
https://github.com/elixir-ecto/postgrex/pull/325.

We now think that it's reasonable to require that the user of myxql has
:ssl installed.