### PR TITLE
Handle socket errors when closing statements

### DIFF
--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -133,8 +133,7 @@ defmodule MyXQL.Client do
   end
 
   def com_stmt_close(client, statement_id) do
-    # No response is sent back to the client.
-    :ok = send_com(client, {:com_stmt_close, statement_id})
+    send_com(client, {:com_stmt_close, statement_id})
   end
 
   def disconnect(%{sock: {sock_mod, sock}}) do


### PR DESCRIPTION
Previously we had `:ok = send_com(...)` which crashes when we got a socket error, e.g.: `{:error, :closed}`. Now, if we stumble upon that we turn it into `{:disconnect, exception, state}` so the connection can be properly restarted.

closes #111