### PR TITLE
Fix typespec for MyXQL.stream/4

### DIFF
--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -27,6 +27,8 @@ defmodule MyXQL do
 
   @type option() :: DBConnection.option()
 
+  @type stream_option() :: option() | {:max_rows, pos_integer()}
+
   @doc """
   Starts the connection process and connects to a MySQL server.
 
@@ -500,7 +502,7 @@ defmodule MyXQL do
 
   And that would be the last result in the stream.
   """
-  @spec stream(DBConnection.t(), iodata | MyXQL.Query.t(), list, [option()]) ::
+  @spec stream(DBConnection.t(), iodata | MyXQL.Query.t(), list, [stream_option()]) ::
           DBConnection.PrepareStream.t()
   def stream(conn, query, params \\ [], opts \\ [])
 


### PR DESCRIPTION
I've stumbled upon this issue when working directly with the library. The type spec for `MyXQL.stream/4` was missing `max_rows` in options definition.