### PR TITLE
accept a string value as for the port

### DIFF
--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -48,7 +48,7 @@ defmodule MyXQL do
 
     * `:hostname` - Server hostname (default: `MYSQL_HOST` env variable, then `"localhost"`)
 
-    * `:port` - Server port (default: `MYSQL_TCP_PORT` env variable, then `3306`)
+    * `:port` - Server port (default: `MYSQL_TCP_PORT` env variable, then `3306`. Accepts either a string or an integer value.)
 
     * `:database` - Database (default: `nil`)
 

--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -256,6 +256,12 @@ defmodule MyXQL.Client do
 
     buffer? = Keyword.has_key?(socket_options, :buffer)
     client = %__MODULE__{connection_id: nil, sock: nil}
+    port = case port do
+      p when is_binary(p) ->
+        String.to_integer(p)
+      p when is_integer(p) ->
+        p
+    end
 
     case :gen_tcp.connect(address, port, socket_options, connect_timeout) do
       {:ok, sock} when buffer? ->


### PR DESCRIPTION
The use case for this is that in my deployment, the mysql port variable gets set from an AWS key/value store (SSM), and they are always strings.