### PR TITLE
encode :zero_datetime and :zero_date

### DIFF
--- a/lib/myxql/protocol/values.ex
+++ b/lib/myxql/protocol/values.ex
@@ -198,11 +198,19 @@ defmodule MyXQL.Protocol.Values do
     {:mysql_type_date, <<4, year::uint2, month::uint1, day::uint1>>}
   end
 
+  def encode_binary_value(:zero_date) do
+    {:mysql_type_date, <<4, 0::uint2, 0::uint1, 0::uint1>>}
+  end
+
   def encode_binary_value(%Time{} = time), do: encode_binary_time(time)
 
   def encode_binary_value(%NaiveDateTime{} = datetime), do: encode_binary_datetime(datetime)
 
   def encode_binary_value(%DateTime{} = datetime), do: encode_binary_datetime(datetime)
+
+  def encode_binary_value(:zero_datetime) do
+    encode_binary_datetime(%NaiveDateTime{ year: 0, month: 0, day: 0, hour: 0, minute: 0, second: 0, microsecond: {0, 0} })
+  end
 
   def encode_binary_value(binary) when is_binary(binary) do
     {:mysql_type_var_string, encode_string_lenenc(binary)}

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -142,6 +142,12 @@ defmodule MyXQL.Protocol.ValueTest do
       end
 
       @tag sql_mode: "ALLOW_INVALID_DATES"
+      test "MYSQL_TYPE_ZERODATES", c do
+        id = insert(c, "my_date", :zero_date)
+        assert get(c, "my_date", id) == :zero_date
+      end
+
+      @tag sql_mode: "ALLOW_INVALID_DATES"
       test "MYSQL_TYPE_DATE - Zero date", c do
         [[value]] = query!(c, "SELECT DATE '0000-00-00'").rows
         assert value in [:zero_date, "0000-00-00"]
@@ -184,6 +190,12 @@ defmodule MyXQL.Protocol.ValueTest do
         id = insert(c, "my_timestamp", ~U[1999-12-31 09:10:20Z])
         query!(c, "SET time_zone = '+08:00'")
         assert get(c, "my_timestamp", id) == ~U[1999-12-31 17:10:20Z]
+      end
+
+      @tag sql_mode: "ALLOW_INVALID_DATES"
+      test "MYSQL_TYPE_ZERODATETIMES", c do
+        id = insert(c, "my_datetime", :zero_datetime)
+        assert get(c, "my_datetime", id) == :zero_datetime
       end
 
       test "MYSQL_TYPE_YEAR", c do


### PR DESCRIPTION
This allows `:zero_date` and `:zero_datetime` to be written back to the DB. My app has `ALLOW_INVALID_DATES` enabled, and other portions of the platform are relying on the date `0000-00-00` to be there. So while decoding of these dates (and timestamps) was already handled by myxql, there was nothing in place to allow writing of these values.

In my case with this change, I have implemented a custom ecto type whose `dump` method looks for a "magic" value and when it sees that value will return `{:ok, :zero_date}` and `0000-00-00` will be correctly written to the db.