### PR TITLE
Delete table on disconnect

### DIFF
--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -56,6 +56,7 @@ defmodule MyXQL.Connection do
 
   @impl true
   def disconnect(_reason, state) do
+    :ets.delete(state.queries)
     Client.disconnect(state.client)
   end
 


### PR DESCRIPTION
If the connection drops, the ETS tables were kept and the number of tables would increase for every disconnection.
The following PR deletes the table using the disconnect callback from DBConnection and the table will be recreated when the connection is established.

