### PR TITLE
Support long passwords (sha256 and caching_sha2)

### DIFF
--- a/lib/myxql/protocol/auth.ex
+++ b/lib/myxql/protocol/auth.ex
@@ -16,9 +16,12 @@ defmodule MyXQL.Protocol.Auth do
 
   def encrypt_sha_password(password, public_key, auth_plugin_data) do
     password = password <> <<0>>
-    xor = auth_plugin_data
-    |> pad_auth_plugin_data(byte_size(password))
-    |> :crypto.exor(password)
+
+    xor =
+      auth_plugin_data
+      |> pad_auth_plugin_data(byte_size(password))
+      |> :crypto.exor(password)
+
     [entry] = :public_key.pem_decode(public_key)
     public_key = :public_key.pem_entry_decode(entry)
     :public_key.encrypt_public(xor, public_key, rsa_pad: :rsa_pkcs1_oaep_padding)
@@ -61,9 +64,15 @@ defmodule MyXQL.Protocol.Auth do
   # Repeat str as needed and truncate final string to target_len
   # E.g. "foobar", 12 -> "foobarfoobar"
   # E.g. "foobar", 15 -> "foobarfoobarfoo"
-  defp pad_auth_plugin_data(str, target_len), do: do_pad_auth_plugin_data(str, byte_size(str), target_len)
+  defp pad_auth_plugin_data(str, target_len),
+    do: do_pad_auth_plugin_data(str, byte_size(str), target_len)
+
   defp do_pad_auth_plugin_data(_str, _str_len, 0), do: ""
   defp do_pad_auth_plugin_data(str, str_len, target_len) when str_len == target_len, do: str
-  defp do_pad_auth_plugin_data(str, str_len, target_len) when str_len > target_len, do: :binary.part(str, 0, target_len)
-  defp do_pad_auth_plugin_data(str, str_len, target_len), do: str <> do_pad_auth_plugin_data(str, str_len, target_len - str_len)
+
+  defp do_pad_auth_plugin_data(str, str_len, target_len) when str_len > target_len,
+    do: :binary.part(str, 0, target_len)
+
+  defp do_pad_auth_plugin_data(str, str_len, target_len),
+    do: str <> do_pad_auth_plugin_data(str, str_len, target_len - str_len)
 end

--- a/lib/myxql/protocol/auth.ex
+++ b/lib/myxql/protocol/auth.ex
@@ -16,7 +16,9 @@ defmodule MyXQL.Protocol.Auth do
 
   def encrypt_sha_password(password, public_key, auth_plugin_data) do
     password = password <> <<0>>
-    xor = :crypto.exor(password, :binary.part(auth_plugin_data, 0, byte_size(password)))
+    xor = auth_plugin_data
+    |> pad_auth_plugin_data(byte_size(password))
+    |> :crypto.exor(password)
     [entry] = :public_key.pem_decode(public_key)
     public_key = :public_key.pem_entry_decode(entry)
     :public_key.encrypt_public(xor, public_key, rsa_pad: :rsa_pkcs1_oaep_padding)
@@ -55,4 +57,13 @@ defmodule MyXQL.Protocol.Auth do
 
   defp bxor_binary(<<l::160>>, <<r::160>>), do: <<l ^^^ r::160>>
   defp bxor_binary(<<l::256>>, <<r::256>>), do: <<l ^^^ r::256>>
+
+  # Repeat str as needed and truncate final string to target_len
+  # E.g. "foobar", 12 -> "foobarfoobar"
+  # E.g. "foobar", 15 -> "foobarfoobarfoo"
+  defp pad_auth_plugin_data(str, target_len), do: do_pad_auth_plugin_data(str, byte_size(str), target_len)
+  defp do_pad_auth_plugin_data(_str, _str_len, 0), do: ""
+  defp do_pad_auth_plugin_data(str, str_len, target_len) when str_len == target_len, do: str
+  defp do_pad_auth_plugin_data(str, str_len, target_len) when str_len > target_len, do: :binary.part(str, 0, target_len)
+  defp do_pad_auth_plugin_data(str, str_len, target_len), do: str <> do_pad_auth_plugin_data(str, str_len, target_len - str_len)
 end

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -102,15 +102,15 @@ defmodule MyXQL.ClientTest do
       assert {:ok, _} = Client.connect(opts)
     end
 
-    # sha256_password_long
+    # Try long passwords that force us to apply the scramble multiple times when XORing
 
-    @tag sha256_password_long: true, public_key_exchange: true
+    @tag sha256_password: true, public_key_exchange: true
     test "sha256_password (long password)" do
       opts = [username: "sha256_password_long", password: "secretsecretsecretsecret"] ++ @opts
       assert {:ok, _} = Client.connect(opts)
     end
 
-    @tag sha256_password_long: true, public_key_exchange: true
+    @tag sha256_password: true, public_key_exchange: true
     test "sha256_password (long password) (bad password)" do
       opts = [username: "sha256_password_long", password: "badbadbadbadbadbadbad"] ++ @opts
       {:error, err_packet(message: "Access denied" <> _)} = Client.connect(opts)
@@ -142,9 +142,9 @@ defmodule MyXQL.ClientTest do
       {:error, err_packet(message: "Access denied" <> _)} = Client.connect(opts)
     end
 
-    # caching_sha2_password
+    # Try long passwords that force us to apply the scramble multiple times when XORing
 
-    @tag caching_sha2_password_long: true, public_key_exchange: true
+    @tag caching_sha2_password: true, public_key_exchange: true
     test "caching_sha2_password (long password) (public key exchange)" do
       opts =
         [username: "caching_sha2_password_long", password: "secretsecretsecretsecret"] ++ @opts
@@ -152,7 +152,7 @@ defmodule MyXQL.ClientTest do
       assert {:ok, _} = Client.connect(opts)
     end
 
-    @tag caching_sha2_password_long: true
+    @tag caching_sha2_password: true
     test "caching_sha2_password (long password) (bad password)" do
       opts = [username: "caching_sha2_password_long", password: "badbadbadbadbadbadbad"] ++ @opts
       {:error, err_packet(message: "Access denied" <> _)} = Client.connect(opts)

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -146,7 +146,9 @@ defmodule MyXQL.ClientTest do
 
     @tag caching_sha2_password_long: true, public_key_exchange: true
     test "caching_sha2_password (long password) (public key exchange)" do
-      opts = [username: "caching_sha2_password_long", password: "secretsecretsecretsecret"] ++ @opts
+      opts =
+        [username: "caching_sha2_password_long", password: "secretsecretsecretsecret"] ++ @opts
+
       assert {:ok, _} = Client.connect(opts)
     end
 

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -102,6 +102,20 @@ defmodule MyXQL.ClientTest do
       assert {:ok, _} = Client.connect(opts)
     end
 
+    # sha256_password_long
+
+    @tag sha256_password_long: true, public_key_exchange: true
+    test "sha256_password (long password)" do
+      opts = [username: "sha256_password_long", password: "secretsecretsecretsecret"] ++ @opts
+      assert {:ok, _} = Client.connect(opts)
+    end
+
+    @tag sha256_password_long: true, public_key_exchange: true
+    test "sha256_password (long password) (bad password)" do
+      opts = [username: "sha256_password_long", password: "badbadbadbadbadbadbad"] ++ @opts
+      {:error, err_packet(message: "Access denied" <> _)} = Client.connect(opts)
+    end
+
     # caching_sha2_password
 
     @tag caching_sha2_password: true, public_key_exchange: true
@@ -125,6 +139,20 @@ defmodule MyXQL.ClientTest do
     @tag caching_sha2_password: true, ssl: true
     test "caching_sha2_password (bad password) (ssl)" do
       opts = [username: "caching_sha2_password", password: "bad", ssl: true] ++ @opts
+      {:error, err_packet(message: "Access denied" <> _)} = Client.connect(opts)
+    end
+
+    # caching_sha2_password
+
+    @tag caching_sha2_password_long: true, public_key_exchange: true
+    test "caching_sha2_password (long password) (public key exchange)" do
+      opts = [username: "caching_sha2_password_long", password: "secretsecretsecretsecret"] ++ @opts
+      assert {:ok, _} = Client.connect(opts)
+    end
+
+    @tag caching_sha2_password_long: true
+    test "caching_sha2_password (long password) (bad password)" do
+      opts = [username: "caching_sha2_password_long", password: "badbadbadbadbadbadbad"] ++ @opts
       {:error, err_packet(message: "Access denied" <> _)} = Client.connect(opts)
     end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -43,8 +43,10 @@ defmodule TestHelper do
     create_user("nopassword", nil, nil)
     create_user("mysql_native", "mysql_native_password", "secret")
     create_user("sha256_password", "sha256_password", "secret")
+    create_user("sha256_password_long", "sha256_password", "secretsecretsecretsecret")
     create_user("sha256_empty", "sha256_password", nil)
     create_user("caching_sha2_password", "caching_sha2_password", "secret")
+    create_user("caching_sha2_password_long", "caching_sha2_password", "secretsecretsecretsecret")
   end
 
   def create_user(username, auth_plugin_name, password) do


### PR DESCRIPTION
An argument error is encountered when trying to authenticate with a sha256 or caching_sha2 password longer than 20 bytes:
```
20:49:08.828 [error] GenServer #PID<0.406.0> terminating
** (ArgumentError) argument error
    (stdlib 3.5) :binary.part(<<105, 5, 61, 82, 25, 87, 87, 33, 9, 14, 54, 64, 20, 74, 2, 93, 37, 68, 77, 111>>, 0, 50)
    (myxql 0.3.4) lib/myxql/protocol/auth.ex:19: MyXQL.Protocol.Auth.encrypt_sha_password/3
    (myxql 0.3.4) lib/myxql/client.ex:402: MyXQL.Client.perform_public_key_auth/5
    (myxql 0.3.4) lib/myxql/client.ex:271: MyXQL.Client.do_handshake/2
    (myxql 0.3.4) lib/myxql/client.ex:252: MyXQL.Client.handshake/2
    (myxql 0.3.4) lib/myxql/connection.ex:32: MyXQL.Connection.connect/1
    (db_connection 2.2.2) lib/db_connection/connection.ex:69: DBConnection.Connection.connect/2
    (connection 1.0.4) lib/connection.ex:622: Connection.enter_connect/5
    (stdlib 3.5) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: nil
State: MyXQL.Connection
```

As part of the login process, MySQL sends a `scramble` value that is 20 bytes long and meant to be XOR-ed (by MyXQL) with the password supplied by the user.  The first line of the backtrace shows that we pass that 20 byte value (stored as `auth_plugin_data`) to `:binary.part` and request 50 bytes (the length of the user's password).  Naturally, that request fails.

Natively, MySQL will cycle through the `scramble` data as many times as needed, in order to match the length of the given password: https://github.com/mysql/mysql-server/blob/f8cdce86448a211511e8a039c62580ae16cb96f5/mysys/crypt_genhash_impl.cc#L438-L444 

This PR adds tests demonstrating the error and a fix that will cycle through `auth_plugin_data` when the user's given password exceeds the length of `auth_plugin_data`.