### PR TITLE
stored procedures with cursor result

### DIFF
--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -502,9 +502,7 @@ defmodule MyXQL.Protocol do
          {:column_defs_eof, column_defs},
          _row_decoder
        ) do
-    if has_status_flag?(status_flags, :server_status_cursor_exists) do
-      "" = next_data
-
+    if has_status_flag?(status_flags, :server_status_cursor_exists) and next_data == "" do
       {:halt,
        resultset(
          column_defs: column_defs,

--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -502,7 +502,10 @@ defmodule MyXQL.Protocol do
          {:column_defs_eof, column_defs},
          _row_decoder
        ) do
-    if has_status_flag?(status_flags, :server_status_cursor_exists) and next_data == "" do
+    if has_status_flag?(status_flags, :server_status_cursor_exists) &&
+         not has_status_flag?(status_flags, :server_more_results_exists) do
+      "" = next_data
+
       {:halt,
        resultset(
          column_defs: column_defs,

--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -502,7 +502,7 @@ defmodule MyXQL.Protocol do
          {:column_defs_eof, column_defs},
          _row_decoder
        ) do
-    if has_status_flag?(status_flags, :server_status_cursor_exists) &&
+    if has_status_flag?(status_flags, :server_status_cursor_exists) and
          not has_status_flag?(status_flags, :server_more_results_exists) do
       "" = next_data
 

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -374,6 +374,10 @@ defmodule MyXQL.ClientTest do
       {:ok, resultset(num_rows: 1, rows: [[3]])} =
         Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
 
+      # This will be called if, for instance, someone issues the procedure statement from Ecto.Adapters.SQL.query
+      {:ok, resultset(num_rows: 1, rows: [[3]])} =
+        Client.com_stmt_execute(client, statement_id, [], :cursor_type_no_cursor)
+
       Client.com_quit(client)
     end
   end

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -371,7 +371,7 @@ defmodule MyXQL.ClientTest do
       {:ok, com_stmt_prepare_ok(statement_id: statement_id)} =
         Client.com_stmt_prepare(client, "CALL cursor_procedure()")
 
-      {:ok, resultset(num_rows: 1, rows: [[3]], status_flags: status_flags)} =
+      {:ok, resultset(num_rows: 1, rows: [[3]])} =
         Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
 
       Client.com_quit(client)

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -366,6 +366,16 @@ defmodule MyXQL.ClientTest do
 
       Client.com_quit(client)
     end
+
+    test "with stored procedure using a cursor", %{client: client} do
+      {:ok, com_stmt_prepare_ok(statement_id: statement_id)} =
+        Client.com_stmt_prepare(client, "CALL cursor_procedure()")
+
+      {:ok, resultset(num_rows: 1, rows: [[3]], status_flags: status_flags)} =
+        Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
+
+      Client.com_quit(client)
+    end
   end
 
   describe "recv_packets/4" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -156,6 +156,31 @@ defmodule TestHelper do
       SELECT 2;
     END$$
     DELIMITER ;
+
+    DROP PROCEDURE IF EXISTS cursor_procedure;
+    DELIMITER $$
+    CREATE PROCEDURE cursor_procedure()
+    BEGIN
+      DECLARE finished BOOLEAN DEFAULT FALSE;
+      DECLARE test_var INT;
+      DECLARE test_cursor CURSOR FOR SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3;
+      DECLARE CONTINUE HANDLER FOR NOT FOUND SET finished = TRUE;
+
+      OPEN test_cursor;
+
+      test_loop: LOOP
+        FETCH test_cursor INTO test_var;
+
+        IF finished THEN
+          LEAVE test_loop;
+        END IF;
+      END LOOP;
+
+      CLOSE test_cursor;
+
+      SELECT test_var AS result;
+    END$$
+    DELIMITER ;
     """)
   end
 


### PR DESCRIPTION
This is an attempt at fixing https://github.com/elixir-ecto/myxql/issues/140.

The error occurs because the stored procedure uses a cursor and tries to return a result. This means after the `column_defs_eof` message, there is still more data and causes the `"" = next_data` match to fail.

This change will allow the stored procedure to perform the cursor operations and still return the result. In the test you can see that the cursor operations happened because the correct value is returned in the final select statement.

All the tests pass, but I'm not sure if there could be scenarios where the cursor flag is set and you need to raise an error when `next_data != ""`. If there are then this PR would need modification.