### PR TITLE
cache changes

### DIFF
--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -213,13 +213,12 @@ defmodule MyXQL do
 
   ## Options
 
-    * `:query_type` - use `:binary` for binary protocol (prepared statements), `:binary_then_text` to attempt
+    * `:query_type` - Use `:binary` for binary protocol (prepared statements), `:binary_then_text` to attempt
       executing a binary query and if that fails fallback to executing a text query, and `:text` for text protocol
-      (default: `:binary`)
+      (default: `:binary`).
 
-    * `:cache_statement` - caches the query with the given name. Opposite to the `name` option
-      given to `prepare/4`, if the cache statement name is reused with a different, the previous
-      query is automatically closed
+    * `:cache_statement` - Caches the query with the given name. If the cache statement
+      name is reused with a different statement, the previous query is automatically closed.
 
   Options are passed to `DBConnection.execute/4` for text protocol, and
   `DBConnection.prepare_execute/4` for binary protocol. See their documentation for all available
@@ -289,7 +288,7 @@ defmodule MyXQL do
   To execute the query, call `execute/4`. To close the query, call `close/3`.
   If a name is given, the name must be unique per query, as the name is cached
   but the statement isn't. If a new statement is given to an old name, the old
-  statement will be the one effectively used.
+  statement will be closed.
 
   ## Options
 

--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -286,9 +286,8 @@ defmodule MyXQL do
   Prepares a query to be later executed.
 
   To execute the query, call `execute/4`. To close the query, call `close/3`.
-  If a name is given, the name must be unique per query, as the name is cached
-  but the statement isn't. If a new statement is given to an old name, the old
-  statement will be closed.
+  If a name is given, the name must be unique per query, as the name is cached.
+  If a new statement uses an old name, the old statement will be closed.
 
   ## Options
 

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -503,10 +503,7 @@ defmodule MyXQL.Connection do
     } = query
 
     try do
-      :ets.insert(
-        state.queries,
-        {name, {statement, num_params, statement_id, ref}, ref}
-      )
+      :ets.insert(state.queries, {name, {statement, num_params, statement_id, ref}, ref})
     rescue
       ArgumentError ->
         :ok

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -556,6 +556,7 @@ defmodule MyXQL.Connection do
         :ets.delete(state.queries, name)
         nil
 
+      # :reference query already prepared
       [{_name, statement_id, _ref}] ->
         Client.com_stmt_close(state.client, statement_id)
         :ets.delete(state.queries, name)


### PR DESCRIPTION
There is some cache behaviour I noticed when studying the code. Some of it is document and some of it isn't. I think there might be some improvements that could be made. I tried looking through the PR/issue history to see if these changes were already considered and didn't find anything. I apologize if I missed it.

Undocumented behaviour:
- Using both the `MyXQL.prepare` and `MyXQL.query` functions with the same query name will cause a match error in `Connection.queries_get`

Documented behaviour:
- If you prepare a query with an already existing name using `MySQL.prepare` it will use the cached value and not update it.

This PR is suggesting to remove `cache: :reference` and make them all statement caches. My rationale is that it better matches the behaviour of the `PREPARE` command in MySQL. In MySQL if you issue a second `PREPARE` statement it will deallocate the first and create the new one. 

I also thought about keeping `cache: :reference` and always closing the previous statement, if a name match is found in the cache. But I thought this way will save some network trips for when the statements are the same. 

If you like this direction I will have to make some doc updates before this can be merged.

Thanks for considering.
