### PR TITLE
query many

### DIFF
--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -357,7 +357,8 @@ defmodule MyXQL.Connection do
   end
 
   defp result({:error, :multiple_results}, _query, _state) do
-    raise RuntimeError, "returning multiple results is not yet supported"
+    raise RuntimeError,
+          "returning multiple results is not supported from this function. please use one of the `_many` functions."
   end
 
   defp result({:error, reason}, _query, state) do

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -3,7 +3,7 @@ defmodule MyXQL.Connection do
 
   use DBConnection
   import MyXQL.Protocol.{Flags, Records}
-  alias MyXQL.{Client, Cursor, Query, Protocol, Result, TextQuery}
+  alias MyXQL.{Client, Cursor, Query, Queries, Protocol, Result, TextQuery, TextQueries}
 
   defstruct [
     :client,
@@ -85,14 +85,25 @@ defmodule MyXQL.Connection do
   end
 
   @impl true
-  def handle_execute(%Query{} = query, params, _opts, state) do
+  def handle_execute(%TextQuery{statement: statement} = query, [], _opts, state) do
+    Client.com_query(state.client, statement, result_state(query))
+    |> result(query, state)
+  end
+
+  def handle_execute(%TextQueries{statement: statement} = query, [], _opts, state) do
+    Client.com_query(state.client, statement, result_state(query))
+    |> result(query, state)
+  end
+
+  def handle_execute(query, params, _opts, state) do
     with {:ok, query, state} <- maybe_reprepare(query, state) do
       result =
         Client.com_stmt_execute(
           state.client,
           query.statement_id,
           params,
-          :cursor_type_no_cursor
+          :cursor_type_no_cursor,
+          result_state(query)
         )
 
       with {:ok, state} <- maybe_close(query, state) do
@@ -101,13 +112,8 @@ defmodule MyXQL.Connection do
     end
   end
 
-  def handle_execute(%TextQuery{statement: statement} = query, [], _opts, state) do
-    Client.com_query(state.client, statement)
-    |> result(query, state)
-  end
-
   @impl true
-  def handle_close(%Query{} = query, _opts, state) do
+  def handle_close(query, _opts, state) do
     with {:ok, state} <- close(query, state) do
       {:ok, nil, state}
     end
@@ -312,6 +318,39 @@ defmodule MyXQL.Connection do
     {:ok, query, result, put_status(state, status_flags)}
   end
 
+  defp result({:ok, resultsets}, query, state) when is_list(resultsets) do
+    {results, status_flags} =
+      Enum.reduce(resultsets, {[], nil}, fn resultset, {results, newest_status_flags} ->
+        resultset(
+          column_defs: column_defs,
+          num_rows: num_rows,
+          rows: rows,
+          status_flags: status_flags,
+          num_warnings: num_warnings
+        ) = resultset
+
+        columns = Enum.map(column_defs, &elem(&1, 1))
+
+        result = %Result{
+          connection_id: state.client.connection_id,
+          columns: columns,
+          num_rows: num_rows,
+          rows: rows,
+          num_warnings: num_warnings
+        }
+
+        # Keep status flags from the last query. The resultsets
+        # are given to this function in reverse order, so it is the first one.
+        if newest_status_flags do
+          {[result | results], newest_status_flags}
+        else
+          {[result | results], status_flags}
+        end
+      end)
+
+    {:ok, query, results, put_status(state, status_flags)}
+  end
+
   defp result({:ok, err_packet() = err_packet}, query, state) do
     exception = error(err_packet, query, state)
     maybe_disconnect(exception, state)
@@ -423,8 +462,8 @@ defmodule MyXQL.Connection do
   defp rename_query(%{prepare: :unnamed}, query),
     do: %{query | name: ""}
 
-  defp prepare(%Query{statement: statement} = query, state) do
-    case Client.com_stmt_prepare(state.client, statement) do
+  defp prepare(query, state) do
+    case Client.com_stmt_prepare(state.client, query.statement) do
       {:ok, com_stmt_prepare_ok(statement_id: statement_id, num_params: num_params)} ->
         ref = make_ref()
         query = %{query | num_params: num_params, statement_id: statement_id, ref: ref}
@@ -451,7 +490,7 @@ defmodule MyXQL.Connection do
   end
 
   # Close unnamed queries after executing them
-  defp maybe_close(%Query{name: ""} = query, state), do: close(query, state)
+  defp maybe_close(%{name: ""} = query, state), do: close(query, state)
   defp maybe_close(_query, state), do: {:ok, state}
 
   defp close(%{ref: ref} = query, %{last_ref: ref} = state) do
@@ -469,14 +508,19 @@ defmodule MyXQL.Connection do
     end
   end
 
+  defp result_state(%TextQuery{}), do: :single
+  defp result_state(%TextQueries{}), do: {:many, []}
+  defp result_state(%Query{}), do: :single
+  defp result_state(%Queries{}), do: {:many, []}
+
   ## Cache query handling
 
   defp queries_new(), do: :ets.new(__MODULE__, [:set, :public])
 
   defp queries_put(%{queries: nil}, _), do: :ok
-  defp queries_put(_state, %Query{name: ""}), do: :ok
+  defp queries_put(_state, %{name: ""}), do: :ok
 
-  defp queries_put(state, %Query{cache: :reference} = query) do
+  defp queries_put(state, %{cache: :reference} = query) do
     %{
       statement_id: statement_id,
       ref: ref,
@@ -493,7 +537,7 @@ defmodule MyXQL.Connection do
     end
   end
 
-  defp queries_put(state, %Query{cache: :statement} = query) do
+  defp queries_put(state, %{cache: :statement} = query) do
     %{
       num_params: num_params,
       statement_id: statement_id,
@@ -513,9 +557,9 @@ defmodule MyXQL.Connection do
   end
 
   defp queries_delete(%{queries: nil}, _), do: :ok
-  defp queries_delete(_state, %Query{name: ""}), do: :ok
+  defp queries_delete(_state, %{name: ""}), do: :ok
 
-  defp queries_delete(state, %Query{name: name}) do
+  defp queries_delete(state, %{name: name}) do
     try do
       :ets.delete(state.queries, name)
     rescue
@@ -526,9 +570,9 @@ defmodule MyXQL.Connection do
   end
 
   defp queries_get(%{queries: nil}, _), do: nil
-  defp queries_get(_state, %Query{name: ""}), do: nil
+  defp queries_get(_state, %{name: ""}), do: nil
 
-  defp queries_get(state, %Query{cache: :reference, name: name}) do
+  defp queries_get(state, %{cache: :reference, name: name}) do
     try do
       :ets.lookup_element(state.queries, name, 2)
     rescue
@@ -541,7 +585,7 @@ defmodule MyXQL.Connection do
     end
   end
 
-  defp queries_get(state, %Query{cache: :statement, name: name, statement: statement} = query) do
+  defp queries_get(state, %{cache: :statement, name: name, statement: statement} = query) do
     try do
       :ets.lookup(state.queries, name)
     rescue
@@ -570,7 +614,7 @@ defmodule MyXQL.Connection do
   defp query_member?(%{queries: nil}, _), do: false
   defp query_member?(_, %{name: ""}), do: false
 
-  defp query_member?(%{queries: queries}, %Query{name: name, ref: ref}) do
+  defp query_member?(%{queries: queries}, %{name: name, ref: ref}) do
     try do
       :ets.lookup_element(queries, name, 3)
     rescue

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -358,7 +358,7 @@ defmodule MyXQL.Connection do
 
   defp result({:error, :multiple_results}, _query, _state) do
     raise RuntimeError,
-          "returning multiple results is not supported from this function. please use one of the `_many` functions."
+          "returning multiple results is not supported from this function. Use MyXQL.query_many/4 and similar functions."
   end
 
   defp result({:error, reason}, _query, state) do

--- a/lib/myxql/query.ex
+++ b/lib/myxql/query.ex
@@ -1,6 +1,10 @@
 defmodule MyXQL.Query do
   @moduledoc """
-  Query struct returned from a successfully prepared query.
+  Query struct returned from a successfully prepared query
+  that returns a single result.
+
+  For the struct returned from a query that returns multiple
+  results, see `MyXQL.Queries`.
 
   Its public fields are:
 
@@ -30,45 +34,81 @@ defmodule MyXQL.Query do
             ref: nil,
             statement: nil,
             statement_id: nil
+end
 
-  defimpl DBConnection.Query do
-    def parse(query, _opts) do
-      query
-    end
+defmodule MyXQL.Queries do
+  @moduledoc """
+  Query struct returned from a successfully prepared query
+  that returns multiple results, i.e. a stored procedure with
+  multiple `SELECT` statements.
 
-    def describe(query, _opts) do
-      query
-    end
+  Its public fields are:
 
-    def encode(%{ref: nil} = query, _params, _opts) do
-      raise ArgumentError, "query #{inspect(query)} has not been prepared"
-    end
+    * `:name` - The name of the prepared statement;
+    * `:num_params` - The number of parameter placeholders;
+    * `:statement` - The prepared statement
 
-    def encode(%{num_params: nil} = query, _params, _opts) do
-      raise ArgumentError, "query #{inspect(query)} has not been prepared"
-    end
+  ## Named and Unnamed Queries
 
-    def encode(%{num_params: num_params} = query, params, _opts)
-        when num_params != length(params) do
-      message =
-        "expected params count: #{inspect(num_params)}, got values: #{inspect(params)}" <>
-          " for query: #{inspect(query)}"
+  Named queries are identified by the non-empty value in `:name` field
+  and are meant to be re-used.
 
-      raise ArgumentError, message
-    end
+  Unnamed queries, with `:name` equal to `""`, are automatically closed
+  after being executed.
+  """
 
-    def encode(_query, params, _opts) do
-      MyXQL.Protocol.encode_params(params)
-    end
+  @type t :: %__MODULE__{
+          name: iodata(),
+          cache: :reference | :statement,
+          num_params: non_neg_integer(),
+          statement: iodata()
+        }
 
-    def decode(_query, result, _opts) do
-      result
-    end
+  defstruct name: "",
+            cache: :reference,
+            num_params: nil,
+            ref: nil,
+            statement: nil,
+            statement_id: nil
+end
+
+defimpl DBConnection.Query, for: [MyXQL.Query, MyXQL.Queries] do
+  def parse(query, _opts) do
+    query
   end
 
-  defimpl String.Chars do
-    def to_string(%{statement: statement}) do
-      IO.iodata_to_binary(statement)
-    end
+  def describe(query, _opts) do
+    query
+  end
+
+  def encode(%{ref: nil} = query, _params, _opts) do
+    raise ArgumentError, "query #{inspect(query)} has not been prepared"
+  end
+
+  def encode(%{num_params: nil} = query, _params, _opts) do
+    raise ArgumentError, "query #{inspect(query)} has not been prepared"
+  end
+
+  def encode(%{num_params: num_params} = query, params, _opts)
+      when num_params != length(params) do
+    message =
+      "expected params count: #{inspect(num_params)}, got values: #{inspect(params)}" <>
+        " for query: #{inspect(query)}"
+
+    raise ArgumentError, message
+  end
+
+  def encode(_query, params, _opts) do
+    MyXQL.Protocol.encode_params(params)
+  end
+
+  def decode(_query, result, _opts) do
+    result
+  end
+end
+
+defimpl String.Chars, for: [MyXQL.Query, MyXQL.Queries] do
+  def to_string(%{statement: statement}) do
+    IO.iodata_to_binary(statement)
   end
 end

--- a/lib/myxql/query.ex
+++ b/lib/myxql/query.ex
@@ -1,7 +1,6 @@
 defmodule MyXQL.Query do
   @moduledoc """
-  Query struct returned from a successfully prepared query
-  that returns a single result.
+  A struct for a prepared statement that returns a single result.
 
   For the struct returned from a query that returns multiple
   results, see `MyXQL.Queries`.
@@ -38,9 +37,10 @@ end
 
 defmodule MyXQL.Queries do
   @moduledoc """
-  Query struct returned from a successfully prepared query
-  that returns multiple results, i.e. a stored procedure with
-  multiple `SELECT` statements.
+  A struct for a prepared statement that returns multiple results.
+
+  An example use case is a stored procedure with multiple `SELECT`
+  statements.
 
   Its public fields are:
 

--- a/lib/myxql/text_query.ex
+++ b/lib/myxql/text_query.ex
@@ -2,24 +2,30 @@ defmodule MyXQL.TextQuery do
   @moduledoc false
 
   defstruct [:statement]
+end
 
-  defimpl DBConnection.Query do
-    def parse(query, _opts), do: query
+defmodule MyXQL.TextQueries do
+  @moduledoc false
 
-    def describe(query, _opts), do: query
+  defstruct [:statement]
+end
 
-    def encode(_query, [], _opts), do: []
+defimpl DBConnection.Query, for: [MyXQL.TextQuery, MyXQL.TextQueries] do
+  def parse(query, _opts), do: query
 
-    def encode(_query, params, _opts) do
-      raise ArgumentError, "text queries cannot use parameters, got: #{inspect(params)}"
-    end
+  def describe(query, _opts), do: query
 
-    def decode(_query, result, _opts), do: result
+  def encode(_query, [], _opts), do: []
+
+  def encode(_query, params, _opts) do
+    raise ArgumentError, "text queries cannot use parameters, got: #{inspect(params)}"
   end
 
-  defimpl String.Chars do
-    def to_string(%{statement: statement}) do
-      IO.iodata_to_binary(statement)
-    end
+  def decode(_query, result, _opts), do: result
+end
+
+defimpl String.Chars, for: [MyXQL.TextQuery, MyXQL.TextQueries] do
+  def to_string(%{statement: statement}) do
+    IO.iodata_to_binary(statement)
   end
 end

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -382,7 +382,7 @@ defmodule MyXQL.ClientTest do
     end
   end
 
-  describe "recv_packets/4" do
+  describe "recv_packets/5" do
     test "simple" do
       %{port: port} =
         start_fake_server(fn %{accept_socket: sock} ->
@@ -394,7 +394,7 @@ defmodule MyXQL.ClientTest do
       end
 
       {:ok, client} = Client.do_connect(Client.Config.new(port: port))
-      assert Client.recv_packets(client, decoder, :initial) == {:ok, "foo"}
+      assert Client.recv_packets(client, decoder, :initial, :single) == {:ok, "foo"}
     end
   end
 

--- a/test/myxql/sync_test.exs
+++ b/test/myxql/sync_test.exs
@@ -79,6 +79,17 @@ defmodule MyXQL.SyncTest do
     assert prepared_stmt_count() == 0
   end
 
+  test "do not leak with single and multiple result queries using the same name" do
+    {:ok, conn} = MyXQL.start_link(@opts)
+    assert prepared_stmt_count() == 0
+
+    {:ok, _} = MyXQL.prepare_many(conn, "foo", "CALL multi_procedure()")
+    assert prepared_stmt_count() == 1
+
+    {:ok, _} = MyXQL.prepare(conn, "foo", "SELECT 42")
+    assert prepared_stmt_count() == 1
+  end
+
   defp prepared_stmt_count() do
     [%{"Value" => count}] = TestHelper.mysql!("show global status like 'Prepared_stmt_count'")
     String.to_integer(count)

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -689,7 +689,7 @@ defmodule MyXQLTest do
     setup :connect
 
     test "using query/4 with a multiple result query", c do
-      assert_raise RuntimeError, ~r"please use one of the `_many` functions", fn ->
+      assert_raise RuntimeError, ~r"returning multiple results is not supported", fn ->
         MyXQL.query(c.conn, "SELECT 1; SELECT 2;", [], query_type: :text)
       end
     end

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -676,7 +676,7 @@ defmodule MyXQLTest do
     test "stream procedure with multiple results", c do
       statement = "CALL multi_procedure()"
 
-      assert_raise RuntimeError, ~r"please use one of the `_many` functions", fn ->
+      assert_raise RuntimeError, ~r"returning multiple results is not supported", fn ->
         MyXQL.transaction(c.conn, fn conn ->
           stream = MyXQL.stream(conn, statement, [], max_rows: 2)
           Enum.to_list(stream)

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -177,6 +177,22 @@ defmodule MyXQLTest do
         assert result.num_rows == num
       end
     end
+
+    test "query_many/4 with text", c do
+      assert {:ok, [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}]} =
+               MyXQL.query_many(c.conn, "SELECT 1; SELECT 2", [], query_type: :text)
+
+      assert {:ok, [%MyXQL.Result{rows: [[1]]}]} =
+               MyXQL.query_many(c.conn, "SELECT 1;", [], query_type: :text)
+    end
+
+    test "query_many!/4 with text", c do
+      assert [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}] =
+               MyXQL.query_many!(c.conn, "SELECT 1; SELECT 2", [], query_type: :text)
+
+      assert [%MyXQL.Result{rows: [[1]]}] =
+               MyXQL.query_many!(c.conn, "SELECT 1;", [], query_type: :text)
+    end
   end
 
   describe ":prepare option" do
@@ -625,21 +641,24 @@ defmodule MyXQLTest do
       assert %MyXQL.Result{rows: [[1]]} =
                MyXQL.query!(c.conn, "CALL single_procedure()", [], query_type: :text)
 
-      assert_raise RuntimeError, "returning multiple results is not yet supported", fn ->
-        assert %MyXQL.Result{rows: [[1]]} = MyXQL.query!(c.conn, "CALL multi_procedure()")
-      end
+      assert [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}] =
+               MyXQL.query_many!(c.conn, "CALL multi_procedure()")
     end
 
     test "prepared query", c do
-      assert {_, %MyXQL.Result{rows: [[1]]}} =
+      assert {%MyXQL.Query{}, %MyXQL.Result{rows: [[1]]}} =
                MyXQL.prepare_execute!(c.conn, "", "CALL single_procedure()")
 
-      assert {_, %MyXQL.Result{rows: [[1]]}} =
+      assert {%MyXQL.Query{}, %MyXQL.Result{rows: [[1]]}} =
                MyXQL.prepare_execute!(c.conn, "", "CALL single_procedure()")
 
-      assert_raise RuntimeError, "returning multiple results is not yet supported", fn ->
-        MyXQL.prepare_execute!(c.conn, "", "CALL multi_procedure()")
-      end
+      assert {%MyXQL.Queries{}, [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}]} =
+               MyXQL.prepare_execute_many!(c.conn, "", "CALL multi_procedure()")
+
+      assert %MyXQL.Queries{} = query = MyXQL.prepare_many!(c.conn, "", "CALL multi_procedure()")
+
+      assert [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}] =
+               MyXQL.execute_many!(c.conn, query)
     end
 
     test "stream procedure with single result", c do
@@ -663,6 +682,84 @@ defmodule MyXQLTest do
           Enum.to_list(stream)
         end)
       end
+    end
+  end
+
+  describe "multiple results" do
+    setup :connect
+
+    test "using query/4 with a multiple result query", c do
+      assert_raise RuntimeError, "returning multiple results is not yet supported", fn ->
+        MyXQL.query(c.conn, "SELECT 1; SELECT 2;", [], query_type: :text)
+      end
+    end
+
+    test "using prepare/4 with a multiple result query", c do
+      {:error, error} = MyXQL.prepare(c.conn, "foo", "SELECT1; SELECT 2;")
+      assert error.message =~ "You have an error in your SQL syntax"
+    end
+
+    test "using prepare_execute/4 with a multiple result query", c do
+      {:error, error} = MyXQL.prepare_execute(c.conn, "foo", "SELECT 1; SELECT2;")
+      assert error.message =~ "You have an error in your SQL syntax"
+    end
+
+    test "using execute/4 with a multiple result query", c do
+      %MyXQL.Queries{} = query = MyXQL.prepare_many!(c.conn, "", "CALL multi_procedure()")
+
+      assert_raise FunctionClauseError, fn ->
+        MyXQL.execute(c.conn, query)
+      end
+    end
+
+    test "using query_many/4 with a single result query", c do
+      assert {:ok, [%MyXQL.Result{rows: [[1]]}]} =
+               MyXQL.query_many(c.conn, "SELECT 1;", [], query_type: :text)
+    end
+
+    test "using query_many/4 with a multiple result query that is not a stored procedure", c do
+      {:error, error} = MyXQL.query_many(c.conn, "SELECT 1; SELECT 2", [], query_type: :binary)
+      assert error.message =~ "You have an error in your SQL syntax"
+    end
+
+    test "using prepare_many/4 with a multiple result query that is not a stored procedure", c do
+      {:error, error} = MyXQL.prepare_many(c.conn, "foo", "SELECT 1; SELECT 2;")
+      assert error.message =~ "You have an error in your SQL syntax"
+    end
+
+    test "using prepare_execute_many/4 with a multiple result query that is not a stored procedure",
+         c do
+      {:error, error} = MyXQL.prepare_execute_many(c.conn, "foo", "SELECT 1; SELECT2;")
+      assert error.message =~ "You have an error in your SQL syntax"
+    end
+
+    test "using prepare_execute_many/4 with a single result query", c do
+      assert {:ok, %MyXQL.Queries{}, [%MyXQL.Result{rows: [[1]]}]} =
+               MyXQL.prepare_execute_many(c.conn, "foo", "SELECT 1;")
+    end
+
+    test "using execute_many/4 with a single result query", c do
+      %MyXQL.Query{} = query = MyXQL.prepare!(c.conn, "", "CALL single_procedure()")
+
+      assert_raise FunctionClauseError, fn ->
+        MyXQL.execute_many(c.conn, query)
+      end
+    end
+
+    test "switching between single and multiple result prepared statement", c do
+      assert %MyXQL.Queries{} =
+               multi_query = MyXQL.prepare_many!(c.conn, "test_name", "CALL multi_procedure()")
+
+      assert assert [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}] =
+                      MyXQL.execute_many!(c.conn, multi_query)
+
+      assert %MyXQL.Query{} = single_query = MyXQL.prepare!(c.conn, "test_name", "SELECT 42;")
+      assert %MyXQL.Result{rows: [[42]]} = MyXQL.execute!(c.conn, single_query)
+    end
+
+    test "close a multiple result prepared statement", c do
+      assert %MyXQL.Queries{} = query = MyXQL.prepare_many!(c.conn, "", "CALL multi_procedure()")
+      assert :ok == MyXQL.close(c.conn, query)
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/myxql/issues/143

Introduces new functions `query_many`, `prepare_many`, `prepare_execute_many` and `execute_many` that allow the user to obtain results for queries that return multiple results, like text queries with multiple statements or stored procedures.

The main idea is:
-  Introduce 2 new structs: MyXQL.Queries and MyXQL.TextQueries 
-  Keep a result state in addition to the decoder state while receiving the packets. 
    - The result state will keep track of whether this is a single or multiple result and if multiple, store the results already obtained. 
    - This lets us decide whether or not to keep going when MySQL says there are more results. And if we are retrieving multiple results to keep the partial results stored somewhere.
    -  Keeping this separate from the decoder state means we don't have to copy the partial results through all of the decoder functions. Or to pass the information to determine whether it's a single or multi result query