### PR TITLE
Prepare unnamed reuse statements

### DIFF
--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -110,14 +110,10 @@ defmodule MyXQL.Connection do
           result_state(query)
         )
 
-      state =
+      {:ok, state} =
         case result do
-          {:ok, err_packet()} ->
-            {:ok, state} = close(query, state)
-            state
-
-          _ ->
-            state
+          {:ok, err_packet()} -> close(query, state)
+          _ -> {:ok, state}
         end
 
       result(result, query, state)

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -29,7 +29,7 @@ defmodule MyXQL.Connection do
           prepare: prepare,
           disconnect_on_error_codes: Keyword.fetch!(opts, :disconnect_on_error_codes),
           ping_timeout: ping_timeout,
-          queries: queries_new()
+          queries: queries_new(prepare)
         }
 
         {:ok, state}
@@ -64,10 +64,9 @@ defmodule MyXQL.Connection do
     query = rename_query(state, query)
 
     if cached_query = queries_get(state, query) do
-      {:ok, cached_query, %{state | last_query: cached_query}}
+      %{ref: ref, statement_id: statement_id} = cached_query
+      {:ok, cached_query, %{state | last_query: {ref, statement_id}}}
     else
-      {:ok, state} = maybe_close(query, state)
-
       case prepare(query, state) do
         {:ok, _, _} = ok ->
           ok
@@ -98,8 +97,6 @@ defmodule MyXQL.Connection do
   end
 
   def handle_execute(query, params, _opts, state) do
-    {:ok, state} = maybe_close(query, state)
-
     with {:ok, query, state} <- maybe_reprepare(query, state) do
       result =
         Client.com_stmt_execute(
@@ -110,13 +107,9 @@ defmodule MyXQL.Connection do
           result_state(query)
         )
 
-      {:ok, state} =
-        case result do
-          {:ok, err_packet()} -> close(query, state)
-          _ -> {:ok, state}
-        end
-
-      result(result, query, state)
+      with {:ok, state} <- maybe_close(query, state) do
+        result(result, query, state)
+      end
     end
   end
 
@@ -477,14 +470,21 @@ defmodule MyXQL.Connection do
         ref = make_ref()
         query = %{query | num_params: num_params, statement_id: statement_id, ref: ref}
         queries_put(state, query)
-        {:ok, query, %{state | last_query: query}}
+        {:ok, query, %{state | last_query: {ref, statement_id}}}
 
       result ->
         result(result, query, state)
     end
   end
 
-  defp maybe_reprepare(query, %{last_query: query} = state), do: {:ok, query, state}
+  defp maybe_reprepare(%{ref: ref} = query, %{last_query: {ref, _statement_id}} = state) do
+    {:ok, query, state}
+  end
+
+  defp maybe_reprepare(query, %{queries: nil, last_query: {_ref, statement_id}} = state) do
+    Client.com_stmt_close(state.client, statement_id)
+    prepare(query, state)
+  end
 
   defp maybe_reprepare(query, state) do
     if query_member?(state, query) do
@@ -498,16 +498,15 @@ defmodule MyXQL.Connection do
     %{state | cursors: Map.delete(state.cursors, cursor.ref)}
   end
 
-  # Close a previous unnamed query if the current query is different
-  defp maybe_close(_query, %{prepare: :unnamed, last_query: last_query} = state)
-       when last_query != nil do
-    close(last_query, state)
-  end
-
-  defp maybe_close(%{ref: ref}, %{last_query: %{ref: ref}} = state), do: {:ok, state}
+  # When prepare is :named, close unnamed queries after executing them.
+  # When prepare is :unnamed, queries will be closed the next time a
+  # query is prepared or a different query is executed. This allows us
+  # to re-execute the same unnamed query without preparing it again.
+  defp maybe_close(_query, %{queries: nil} = state), do: {:ok, state}
+  defp maybe_close(%Query{name: ""} = query, state), do: close(query, state)
   defp maybe_close(_query, state), do: {:ok, state}
 
-  defp close(query, %{last_query: query} = state) do
+  defp close(%{ref: ref} = query, %{last_query: {ref, _statement_id}} = state) do
     close(query, %{state | last_query: nil})
   end
 
@@ -529,7 +528,8 @@ defmodule MyXQL.Connection do
 
   ## Cache query handling
 
-  defp queries_new(), do: :ets.new(__MODULE__, [:set, :public])
+  defp queries_new(:unnamed), do: nil
+  defp queries_new(_), do: :ets.new(__MODULE__, [:set, :public])
 
   defp queries_put(%{queries: nil}, _), do: :ok
   defp queries_put(_state, %{name: ""}), do: :ok
@@ -583,7 +583,11 @@ defmodule MyXQL.Connection do
     end
   end
 
-  defp queries_get(%{queries: nil}, _), do: nil
+  defp queries_get(%{queries: nil, last_query: {_ref, statement_id}} = state, _query) do
+    Client.com_stmt_close(state.client, statement_id)
+    nil
+  end
+
   defp queries_get(_state, %{name: ""}), do: nil
 
   defp queries_get(state, %{cache: :reference, name: name}) do

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -503,7 +503,7 @@ defmodule MyXQL.Connection do
   # query is prepared or a different query is executed. This allows us
   # to re-execute the same unnamed query without preparing it again.
   defp maybe_close(_query, %{queries: nil} = state), do: {:ok, state}
-  defp maybe_close(%Query{name: ""} = query, state), do: close(query, state)
+  defp maybe_close(%{name: ""} = query, state), do: close(query, state)
   defp maybe_close(_query, state), do: {:ok, state}
 
   defp close(%{ref: ref} = query, %{last_query: {ref, _statement_id}} = state) do

--- a/test/myxql/sync_test.exs
+++ b/test/myxql/sync_test.exs
@@ -25,7 +25,7 @@ defmodule MyXQL.SyncTest do
     MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
     assert prepared_stmt_count() == 1
 
-    MyXQL.query!(conn, "SELECT 1337", [], cache_statement: "69")
+    MyXQL.query!(conn, "SELECT 1337", [], cache_statement: "1337")
     assert prepared_stmt_count() == 2
 
     MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")

--- a/test/myxql/sync_test.exs
+++ b/test/myxql/sync_test.exs
@@ -12,6 +12,26 @@ defmodule MyXQL.SyncTest do
     assert prepared_stmt_count() == 0
   end
 
+  test "produce the expected amount of prepared statements in named mode" do
+    {:ok, conn} = MyXQL.start_link(@opts)
+    assert prepared_stmt_count() == 0
+
+    MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
+    assert prepared_stmt_count() == 1
+
+    MyXQL.query!(conn, "SELECT 1337", [], cache_statement: "69")
+    assert prepared_stmt_count() == 2
+
+    MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
+    assert prepared_stmt_count() == 2
+
+    MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
+    assert prepared_stmt_count() == 2
+
+    MyXQL.query!(conn, "SELECT 43", [], cache_statement: "43")
+    assert prepared_stmt_count() == 3
+  end
+
   test "do not leak statements with rebound :cache_statement" do
     {:ok, conn} = MyXQL.start_link(@opts)
     assert prepared_stmt_count() == 0

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -209,7 +209,8 @@ defmodule MyXQLTest do
       {:ok, pid} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
       {:ok, query} = MyXQL.prepare(pid, "1", "SELECT 1")
       {:ok, query2, _} = MyXQL.execute(pid, query, [])
-      assert query == query2
+      assert query.ref != query2.ref
+      assert query.statement_id != query2.statement_id
       {:ok, query3, _} = MyXQL.execute(pid, query, [])
       assert query2.ref != query3.ref
       assert query2.statement_id != query3.statement_id

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -205,15 +205,26 @@ defmodule MyXQLTest do
       assert query == query3
     end
 
-    test ":unnamed" do
+    test ":unnamed re-executes last query without preparing" do
       {:ok, pid} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
       {:ok, query} = MyXQL.prepare(pid, "1", "SELECT 1")
       {:ok, query2, _} = MyXQL.execute(pid, query, [])
-      assert query.ref != query2.ref
-      assert query.statement_id != query2.statement_id
+      assert query == query2
       {:ok, query3, _} = MyXQL.execute(pid, query, [])
-      assert query2.ref != query3.ref
-      assert query2.statement_id != query3.statement_id
+      assert query2 == query3
+    end
+
+    test ":unnamed re-prepares if last query is not the same" do
+      {:ok, pid} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
+
+      {:ok, query1} = MyXQL.prepare(pid, "1", "SELECT 1")
+      {:ok, query2} = MyXQL.prepare(pid, "2", "SELECT 2")
+
+      {:ok, query1b, _} = MyXQL.execute(pid, query1, [])
+      {:ok, query2b, _} = MyXQL.execute(pid, query2, [])
+
+      assert query1 != query1b
+      assert query2 != query2b
     end
 
     test ":force_named" do


### PR DESCRIPTION
This continues the work of @hkrutzer  in https://github.com/elixir-ecto/myxql/pull/126 and https://github.com/elixir-ecto/myxql/pull/92.

The idea is to cache the last prepared query in unnamed mode and reuse it when you can. To summarize:


For unnamed:
  - don't immediately close the query
  - close the last query on new prepare or execution of a different query

For named:
  - keep the same behaviour immediately closing queries with "" name (i.e. if they call query without specifying cache_statement).
