### PR TITLE
Cache issues

### DIFF
--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -213,13 +213,12 @@ defmodule MyXQL do
 
   ## Options
 
-    * `:query_type` - use `:binary` for binary protocol (prepared statements), `:binary_then_text` to attempt
+    * `:query_type` - Use `:binary` for binary protocol (prepared statements), `:binary_then_text` to attempt
       executing a binary query and if that fails fallback to executing a text query, and `:text` for text protocol
-      (default: `:binary`)
+      (default: `:binary`).
 
-    * `:cache_statement` - caches the query with the given name. Opposite to the `name` option
-      given to `prepare/4`, if the cache statement name is reused with a different, the previous
-      query is automatically closed
+    * `:cache_statement` - Caches the query with the given name. If the cache statement
+      name is reused with a different statement, the previous query is automatically closed.
 
   Options are passed to `DBConnection.execute/4` for text protocol, and
   `DBConnection.prepare_execute/4` for binary protocol. See their documentation for all available
@@ -361,9 +360,8 @@ defmodule MyXQL do
   Prepares a query that returns a single result to be later executed.
 
   To execute the query, call `execute/4`. To close the query, call `close/3`.
-  If a name is given, the name must be unique per query, as the name is cached
-  but the statement isn't. If a new statement is given to an old name, the old
-  statement will be the one effectively used.
+  If a name is given, the name must be unique per query, as the name is cached.
+  If a new statement uses an old name, the old statement will be closed.
 
   ## Options
 

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -479,8 +479,8 @@ defmodule MyXQL.Connection do
   defp maybe_reprepare(%{ref: ref} = query, %{last_ref: ref} = state), do: {:ok, query, state}
 
   defp maybe_reprepare(query, state) do
-    if cached_query = queries_get(state, query) do
-      {:ok, cached_query, state}
+    if query_member?(state, query) do
+      {:ok, query, state}
     else
       prepare(query, state)
     end
@@ -523,14 +523,13 @@ defmodule MyXQL.Connection do
 
   defp queries_put(state, %{cache: :reference} = query) do
     %{
-      num_params: num_params,
       statement_id: statement_id,
       ref: ref,
       name: name
     } = query
 
     try do
-      :ets.insert(state.queries, {name, {num_params, statement_id, ref}})
+      :ets.insert(state.queries, {name, statement_id, ref})
     rescue
       ArgumentError ->
         :ok
@@ -549,7 +548,7 @@ defmodule MyXQL.Connection do
     } = query
 
     try do
-      :ets.insert(state.queries, {name, {statement, num_params, statement_id, ref}})
+      :ets.insert(state.queries, {name, statement_id, ref, statement, num_params})
     rescue
       ArgumentError ->
         :ok
@@ -574,30 +573,56 @@ defmodule MyXQL.Connection do
   defp queries_get(%{queries: nil}, _), do: nil
   defp queries_get(_state, %{name: ""}), do: nil
 
-  defp queries_get(state, %{cache: :reference, name: name} = query) do
+  defp queries_get(state, %{cache: :reference, name: name}) do
     try do
       :ets.lookup_element(state.queries, name, 2)
     rescue
       ArgumentError -> nil
     else
-      {num_params, statement_id, ref} ->
-        %{query | num_params: num_params, statement_id: statement_id, ref: ref}
+      statement_id ->
+        Client.com_stmt_close(state.client, statement_id)
+        :ets.delete(state.queries, name)
+        nil
     end
   end
 
   defp queries_get(state, %{cache: :statement, name: name, statement: statement} = query) do
     try do
-      :ets.lookup_element(state.queries, name, 2)
+      :ets.lookup(state.queries, name)
     rescue
       ArgumentError -> nil
     else
-      {^statement, num_params, statement_id, ref} ->
+      # :statement query already prepared
+      [{_name, statement_id, ref, ^statement, num_params}] ->
         %{query | num_params: num_params, statement_id: statement_id, ref: ref}
 
-      {_statement, _num_params, statement_id, _ref} ->
+      [{_name, statement_id, _ref, _statement, _num_params}] ->
         Client.com_stmt_close(state.client, statement_id)
         :ets.delete(state.queries, name)
         nil
+
+      # :reference query already prepared
+      [{_name, statement_id, _ref}] ->
+        Client.com_stmt_close(state.client, statement_id)
+        :ets.delete(state.queries, name)
+        nil
+
+      [] ->
+        nil
+    end
+  end
+
+  defp query_member?(%{queries: nil}, _), do: false
+  defp query_member?(_, %{name: ""}), do: false
+
+  defp query_member?(%{queries: queries}, %{name: name, ref: ref}) do
+    try do
+      :ets.lookup_element(queries, name, 3)
+    rescue
+      ArgumentError -> false
+    else
+      ^ref -> true
+      _ -> false
     end
   end
 end

--- a/test/myxql/sync_test.exs
+++ b/test/myxql/sync_test.exs
@@ -8,8 +8,36 @@ defmodule MyXQL.SyncTest do
     {:ok, conn} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
     assert prepared_stmt_count() == 0
 
+    # Multiple queries do not increase statement count
     MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
+    assert prepared_stmt_count() == 1
+
+    MyXQL.query!(conn, "SELECT 43", [], cache_statement: "43")
+    assert prepared_stmt_count() == 1
+
+    # Multiple preparations don't increase statement count
+    {:ok, _query} = MyXQL.prepare(conn, "1", "SELECT 1")
+    assert prepared_stmt_count() == 1
+
+    {:ok, _query} = MyXQL.prepare(conn, "2", "SELECT 2")
+    assert prepared_stmt_count() == 1
+  end
+
+  test "do not leak statements with prepare: :named" do
+    {:ok, conn} = MyXQL.start_link(@opts)
     assert prepared_stmt_count() == 0
+
+    MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
+    assert prepared_stmt_count() == 1
+
+    MyXQL.query!(conn, "SELECT 1337", [], cache_statement: "1337")
+    assert prepared_stmt_count() == 2
+
+    MyXQL.query!(conn, "SELECT 42", [], cache_statement: "42")
+    assert prepared_stmt_count() == 2
+
+    MyXQL.query!(conn, "SELECT 43", [])
+    assert prepared_stmt_count() == 2
   end
 
   test "do not leak statements with rebound :cache_statement" do
@@ -23,13 +51,29 @@ defmodule MyXQL.SyncTest do
     assert prepared_stmt_count() == 1
   end
 
-  test "do not leak statements with insert and failed insert" do
+  test "do not leak statements with insert and failed insert with prepare: :named" do
     {:ok, conn} = MyXQL.start_link(@opts)
     assert prepared_stmt_count() == 0
+
     {:ok, _} = MyXQL.query(conn, "INSERT INTO uniques(a) VALUES (1)")
     assert prepared_stmt_count() == 0
+
     {:error, _} = MyXQL.query(conn, "INSERT INTO uniques(a) VALUES (1)")
     assert prepared_stmt_count() == 0
+  end
+
+  test "do not leak statements with insert and failed insert with prepare: :unnamed" do
+    {:ok, conn} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
+    assert prepared_stmt_count() == 0
+
+    {:ok, _} = MyXQL.query(conn, "INSERT INTO uniques(a) VALUES (2)")
+    assert prepared_stmt_count() == 1
+
+    {:error, _} = MyXQL.query(conn, "INSERT INTO uniques(a) VALUES (2)")
+    assert prepared_stmt_count() == 1
+
+    MyXQL.query!(conn, "SELECT 123", [], cache_statement: "123")
+    assert prepared_stmt_count() == 1
   end
 
   test "do not leak statements on multiple executions of the same name in prepare_execute" do

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -205,14 +205,26 @@ defmodule MyXQLTest do
       assert query == query3
     end
 
-    test ":unnamed" do
+    test ":unnamed re-executes last query without preparing" do
       {:ok, pid} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
       {:ok, query} = MyXQL.prepare(pid, "1", "SELECT 1")
       {:ok, query2, _} = MyXQL.execute(pid, query, [])
       assert query == query2
       {:ok, query3, _} = MyXQL.execute(pid, query, [])
-      assert query2.ref != query3.ref
-      assert query2.statement_id != query3.statement_id
+      assert query2 == query3
+    end
+
+    test ":unnamed re-prepares if last query is not the same" do
+      {:ok, pid} = MyXQL.start_link(@opts ++ [prepare: :unnamed])
+
+      {:ok, query1} = MyXQL.prepare(pid, "1", "SELECT 1")
+      {:ok, query2} = MyXQL.prepare(pid, "2", "SELECT 2")
+
+      {:ok, query1b, _} = MyXQL.execute(pid, query1, [])
+      {:ok, query2b, _} = MyXQL.execute(pid, query2, [])
+
+      assert query1 != query1b
+      assert query2 != query2b
     end
 
     test ":force_named" do

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -243,18 +243,19 @@ defmodule MyXQLTest do
     end
 
     test "prepare and then execute with name", c do
-      {:ok, query} = MyXQL.prepare(c.conn, "foo", "SELECT ? * ?")
+      {:ok, query1} = MyXQL.prepare(c.conn, "foo", "SELECT ? * ?")
 
-      assert query.num_params == 2
-      assert {:ok, _, result} = MyXQL.execute(c.conn, query, [2, 3])
+      assert query1.num_params == 2
+      assert {:ok, _, result} = MyXQL.execute(c.conn, query1, [2, 3])
       assert result.rows == [[6]]
 
-      # If we prepare it again, it won't make a difference if the name is the same
-      {:ok, query} = MyXQL.prepare(c.conn, "foo", "SELECT ? + ?")
+      # If we prepare it again with the same name it will use the new statement
+      {:ok, query2} = MyXQL.prepare(c.conn, "foo", "SELECT ? + ?")
 
-      assert query.num_params == 2
-      assert {:ok, _, result} = MyXQL.execute(c.conn, query, [2, 3])
-      assert result.rows == [[6]]
+      assert query2.num_params == 2
+      assert {:ok, _, result} = MyXQL.execute(c.conn, query2, [2, 3])
+      assert result.rows == [[5]]
+      assert query1.ref != query2.ref
     end
 
     test "query is re-prepared if executed after being closed", c do
@@ -295,6 +296,16 @@ defmodule MyXQLTest do
       {:ok, query2, %{rows: [[42]]}} = MyXQL.execute(conn2, query1, [])
       assert query1.ref != query2.ref
       assert query1.statement_id != query2.statement_id
+    end
+
+    test "prepare and then query with the same name", c do
+      {:ok, _query} = MyXQL.prepare(c.conn, "foo", "SELECT 42")
+      {:ok, %{rows: [[24]]}} = MyXQL.query(c.conn, "SELECT 24", [], cache_statement: "foo")
+    end
+
+    test "query and then prepare_execute with the same name", c do
+      {:ok, %{rows: [[24]]}} = MyXQL.query(c.conn, "SELECT 24", [], cache_statement: "foo")
+      {:ok, _query, %{rows: [[42]]}} = MyXQL.prepare_execute(c.conn, "foo", "SELECT 42")
     end
 
     # This test is just describing existing behaviour, we may want to change it in the future.
@@ -733,6 +744,17 @@ defmodule MyXQLTest do
       assert_raise FunctionClauseError, fn ->
         MyXQL.execute_many(c.conn, query)
       end
+    end
+
+    test "switching between single and multiple result prepared statement", c do
+      assert %MyXQL.Queries{} =
+               multi_query = MyXQL.prepare_many!(c.conn, "test_name", "CALL multi_procedure()")
+
+      assert [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{rows: [[2]]}] =
+               MyXQL.execute_many!(c.conn, multi_query)
+
+      assert %MyXQL.Query{} = single_query = MyXQL.prepare!(c.conn, "test_name", "SELECT 42;")
+      assert %MyXQL.Result{rows: [[42]]} = MyXQL.execute!(c.conn, single_query)
     end
 
     test "close a multiple result prepared statement", c do


### PR DESCRIPTION
If you guys still want to keep the cache changes from the 2 reverted commits, this branch could be tested by the affected people. Though if you'd rather just get rid of them I completely understand.  The first 2 commits here are the revert of the reverts and the last is the fix. 

~~Since the test suite passes and I can't replicate the issues locally, I really feel like it's a multi-node setup issue. To summarize from https://github.com/elixir-ecto/myxql/issues/147:~~

~~In multi-node setups prepared statements with the same name can be saved with different refs. If it was prepared on one node then executed on another it will be re-prepared and the next time it's executed on the original node, the refs won't match and it will be re-prepared again.~~

~~Before the cache change commit, executions would check for the name and not the ref. So each node would only be able to re-prepare an existing statement once.~~

~~Though there are still some complications with multi-node set-ups for re-preparing statements with the same name but a different query. But that happens with or without the reverted commits.~~

~~Edit: actually thinking more about the multi-node setup. I think it's important for cache names too be able to be re-prepared. Say you have 2 nodes both with the same prepared query cached on them. Then this sequence happens:~~

~~1. Close the prepared statement on node 1
2. Re-prepare a new statement with the same name on node 2. It's still in the cache so the old one will be picked up and returned.~~

~~So always closing the old statements on re-prepare circumvents that issue.~~

^ don't believe this is correct anymore. i gave a detailed comment below of what i believe the issue is, with tests