### PR TITLE
fixes for query_many and its variants

### DIFF
--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -211,6 +211,14 @@ defmodule MyXQL do
         * requires two roundtrips to the DB server: one for preparing the statement and one for executing it.
           This can be alleviated by holding on to prepared statement and executing it multiple times.
 
+  ## Stored procedures
+
+  A successfully executed stored procedure always returns the affected row count
+  of the last statement. This means any stored procedure containing statements that
+  return result sets, such as `SELECT` statements, must use `query_many/4` and
+  similar functions. These functions will return one result for each statement
+  returning a result set and one for the affected row count of the last statement.
+
   ## Options
 
     * `:query_type` - use `:binary` for binary protocol (prepared statements), `:binary_then_text` to attempt
@@ -365,6 +373,14 @@ defmodule MyXQL do
   but the statement isn't. If a new statement is given to an old name, the old
   statement will be the one effectively used.
 
+  ## Stored procedures
+
+  A successfully executed stored procedure always returns the affected row count
+  of the last statement. This means any stored procedure containing statements that
+  return result sets, such as `SELECT` statements, must use `prepare_many/4` and similar
+  functions. These functions will return one result for each statement returning a
+  result set and one for the affected row count of the last statement.
+
   ## Options
 
   Options are passed to `DBConnection.prepare/3`, see it's documentation for
@@ -417,7 +433,7 @@ defmodule MyXQL do
   ## Examples
 
       iex> {:ok, query} = MyXQL.prepare_many(conn, "", "CALL multi_procedure()")
-      iex> {:ok, [%MyXQL.Result{rows: [row1]}, %MyXQL.Result{rows: [row2]}]} = MyXQL.execute_many(conn, query, [2, 3])
+      iex> {:ok, [%MyXQL.Result{rows: [row1]}, %MyXQL.Result{rows: [row2]}, %MyXQL.Result{rows: nil}]} = MyXQL.execute_many(conn, query, [2, 3])
       iex> row1
       [2]
       iex> row2
@@ -448,6 +464,14 @@ defmodule MyXQL do
 
   @doc """
   Prepares and executes a query that returns a single result, in a single step.
+
+  ## Stored procedures
+
+  A successfully executed stored procedure always returns the affected row count
+  of the last statement. This means any stored procedure containing statements that
+  return result sets, such as `SELECT` statements, must use `prepare_execute_many/5`
+  and similar functions. These functions will return one result for each statement
+  returning a result set and one for the affected row count of the last statement.
 
   ## Options
 
@@ -499,7 +523,7 @@ defmodule MyXQL do
 
   ## Examples
 
-      iex> {:ok, _, [%MyXQL.Result{rows: [row1]}, %MyXQL.Result{rows: [row2]}]} = MyXQL.prepare_execute(conn, "", "CALL multi_procedure()")
+      iex> {:ok, _, [%MyXQL.Result{rows: [row1]}, %MyXQL.Result{rows: [row2]}, %MyXQL.Result{rows: nil}]} = MyXQL.prepare_execute(conn, "", "CALL multi_procedure()")
       iex> row1
       [2]
       iex> row2
@@ -532,6 +556,14 @@ defmodule MyXQL do
 
   @doc """
   Executes a prepared query that returns a single result.
+
+  ## Stored procedures
+
+  A successfully executed stored procedure always returns the affected row count
+  of the last statement. This means any stored procedure containing statements that
+  return result sets, such as `SELECT` statements, must use execute_many/4 and
+  similar functions. These functions will return one result for each statement
+  returning a result set and one for the affected row count of the last statement.
 
   ## Options
 
@@ -575,7 +607,7 @@ defmodule MyXQL do
   ## Examples
 
       iex> {:ok, query} = MyXQL.prepare_many(conn, "", "CALL multi_procedure()")
-      iex> {:ok, [%MyXQL.Result{rows: [row1]}, %MyXQL.Result{rows: [row2]}]} = MyXQL.execute_many(conn, query)
+      iex> {:ok, [%MyXQL.Result{rows: [row1]}, %MyXQL.Result{rows: [row2]}, %MyXQL.Result{rows: nil}]} = MyXQL.execute_many(conn, query)
       iex> row1
       [2]
       iex> row2

--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -232,7 +232,7 @@ defmodule MyXQL do
 
   In contrast to this, a stored procedure that doesn't contain row-returning
   statements can use this function. In this scenario, only the final result
-  with the number of rows affected by the last statment will be returned.
+  with the number of rows affected by the last statement will be returned.
 
   Take, for example, the following stored procedure:
 
@@ -423,7 +423,7 @@ defmodule MyXQL do
 
   In contrast to this, a stored procedure that doesn't contain row-returning
   statements can use this function. In this scenario, only the final result
-  with the number of rows affected by the last statment will be returned.
+  with the number of rows affected by the last statement will be returned.
 
   Take, for example, the following stored procedure:
 
@@ -544,7 +544,7 @@ defmodule MyXQL do
 
   In contrast to this, a stored procedure that doesn't contain row-returning
   statements can use this function. In this scenario, only the final result
-  with the number of rows affected by the last statment will be returned.
+  with the number of rows affected by the last statement will be returned.
 
   Take, for example, the following stored procedure:
 
@@ -665,7 +665,7 @@ defmodule MyXQL do
 
   In contrast to this, a stored procedure that doesn't contain row-returning
   statements can use this function. In this scenario, only the final result
-  with the number of rows affected by the last statment will be returned.
+  with the number of rows affected by the last statement will be returned.
 
   Take, for example, the following stored procedure:
 

--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -213,11 +213,40 @@ defmodule MyXQL do
 
   ## Stored procedures
 
-  A successfully executed stored procedure always returns the affected row count
-  of the last statement. This means any stored procedure containing statements that
-  return result sets, such as `SELECT` statements, must use `query_many/4` and
-  similar functions. These functions will return one result for each statement
-  returning a result set and one for the affected row count of the last statement.
+  A stored procedure containing statements that return rows, such as `SELECT`
+  statements, must use `query_many/4` and similar functions. This is because
+  stored procedures always return a final result with the number of rows affected
+  by the last statement.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        SELECT 1;
+      END$$
+      DELIMITER ;
+
+  There will be one result for the `SELECT 1` statement and another result
+  stating that 0 rows were affected by the last statement.
+
+  In contrast to this, a stored procedure that doesn't contain row-returning
+  statements can use this function. In this scenario, only the final result
+  with the number of rows affected by the last statment will be returned.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        CREATE TABLE IF NOT EXISTS integers (x int);
+        INSERT INTO integers VALUES (10);
+      END$$
+      DELIMITER ;
+
+  Because `CREATE` and `INSERT` statements do not return rows, there will be a
+  single result stating that 1 row was affected by the last statement. This is
+  referencing the row that was inserted.
 
   ## Options
 
@@ -375,11 +404,40 @@ defmodule MyXQL do
 
   ## Stored procedures
 
-  A successfully executed stored procedure always returns the affected row count
-  of the last statement. This means any stored procedure containing statements that
-  return result sets, such as `SELECT` statements, must use `prepare_many/4` and similar
-  functions. These functions will return one result for each statement returning a
-  result set and one for the affected row count of the last statement.
+  A stored procedure containing statements that return rows, such as `SELECT`
+  statements, must use `prepare_many/4` and similar functions. This is because
+  stored procedures always return a final result with the number of rows affected
+  by the last statement.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        SELECT 1;
+      END$$
+      DELIMITER ;
+
+  There will be one result for the `SELECT 1` statement and another result
+  stating that 0 rows were affected by the last statement.
+
+  In contrast to this, a stored procedure that doesn't contain row-returning
+  statements can use this function. In this scenario, only the final result
+  with the number of rows affected by the last statment will be returned.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        CREATE TABLE IF NOT EXISTS integers (x int);
+        INSERT INTO integers VALUES (10);
+      END$$
+      DELIMITER ;
+
+  Because `CREATE` and `INSERT` statements do not return rows, there will be a
+  single result stating that 1 row was affected by the last statement. This is
+  referencing the row that was inserted.
 
   ## Options
 
@@ -467,11 +525,40 @@ defmodule MyXQL do
 
   ## Stored procedures
 
-  A successfully executed stored procedure always returns the affected row count
-  of the last statement. This means any stored procedure containing statements that
-  return result sets, such as `SELECT` statements, must use `prepare_execute_many/5`
-  and similar functions. These functions will return one result for each statement
-  returning a result set and one for the affected row count of the last statement.
+  A stored procedure containing statements that return rows, such as `SELECT`
+  statements, must use `prepare_execute_many/5` and similar functions. This is because
+  stored procedures always return a final result with the number of rows affected
+  by the last statement.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        SELECT 1;
+      END$$
+      DELIMITER ;
+
+  There will be one result for the `SELECT 1` statement and another result
+  stating that 0 rows were affected by the last statement.
+
+  In contrast to this, a stored procedure that doesn't contain row-returning
+  statements can use this function. In this scenario, only the final result
+  with the number of rows affected by the last statment will be returned.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        CREATE TABLE IF NOT EXISTS integers (x int);
+        INSERT INTO integers VALUES (10);
+      END$$
+      DELIMITER ;
+
+  Because `CREATE` and `INSERT` statements do not return rows, there will be a
+  single result stating that 1 row was affected by the last statement. This is
+  referencing the row that was inserted.
 
   ## Options
 
@@ -559,11 +646,40 @@ defmodule MyXQL do
 
   ## Stored procedures
 
-  A successfully executed stored procedure always returns the affected row count
-  of the last statement. This means any stored procedure containing statements that
-  return result sets, such as `SELECT` statements, must use execute_many/4 and
-  similar functions. These functions will return one result for each statement
-  returning a result set and one for the affected row count of the last statement.
+  A stored procedure containing statements that return rows, such as `SELECT`
+  statements, must use `execute_many/4` and similar functions. This is because
+  stored procedures always return a final result with the number of rows affected
+  by the last statement.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        SELECT 1;
+      END$$
+      DELIMITER ;
+
+  There will be one result for the `SELECT 1` statement and another result
+  stating that 0 rows were affected by the last statement.
+
+  In contrast to this, a stored procedure that doesn't contain row-returning
+  statements can use this function. In this scenario, only the final result
+  with the number of rows affected by the last statment will be returned.
+
+  Take, for example, the following stored procedure:
+
+      DELIMITER $$
+      CREATE PROCEDURE stored_procedure()
+      BEGIN
+        CREATE TABLE IF NOT EXISTS integers (x int);
+        INSERT INTO integers VALUES (10);
+      END$$
+      DELIMITER ;
+
+  Because `CREATE` and `INSERT` statements do not return rows, there will be a
+  single result stating that 1 row was affected by the last statement. This is
+  referencing the row that was inserted.
 
   ## Options
 

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -225,7 +225,7 @@ defmodule MyXQL.Connection do
         end
 
       other ->
-        result(other, query, state)
+        stream_result(other, query, state)
     end
   end
 
@@ -245,7 +245,7 @@ defmodule MyXQL.Connection do
         end
 
       other ->
-        result(other, query, state)
+        stream_result(other, query, state)
     end
   end
 
@@ -271,6 +271,14 @@ defmodule MyXQL.Connection do
   end
 
   ## Internals
+  defp stream_result({:error, :multiple_results}, _query, _state) do
+    raise RuntimeError,
+          "streaming stored procedures is not supported. Use MyXQL.query_many/4 and similar functions."
+  end
+
+  defp stream_result(result, query, state) do
+    result(result, query, state)
+  end
 
   defp result({:ok, ok_packet(status_flags: status_flags) = result}, query, state) do
     {:ok, query, format_result(result, state), put_status(state, status_flags)}

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -273,8 +273,8 @@ defmodule MyXQL.Connection do
   ## Internals
 
   # This error can only be received when attempting to stream a stored procedure.
-  # Attemping to stream a text query with multiple-statements separated by a semi-colon
-  # will return a syntax error.
+  # Attemping to stream a text query with statements separated by semi-colons will
+  # return a syntax error.
   defp stream_result({:error, :multiple_results}, _query, _state) do
     raise RuntimeError,
           "streaming stored procedures is not supported. Use MyXQL.query_many/4 and similar functions."

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -350,7 +350,7 @@ defmodule MyXQL.ClientTest do
       {:ok, com_stmt_prepare_ok(statement_id: statement_id)} =
         Client.com_stmt_prepare(client, "CALL single_ok_procedure()")
 
-      {:ok, ok_packet(affected_rows: 1, status_flags: status_flags)} =
+      {:ok, ok_packet(status_flags: status_flags)} =
         Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
 
       assert list_status_flags(status_flags) == [:server_status_autocommit]

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -348,9 +348,9 @@ defmodule MyXQL.ClientTest do
 
     test "with stored procedure of single result", %{client: client} do
       {:ok, com_stmt_prepare_ok(statement_id: statement_id)} =
-        Client.com_stmt_prepare(client, "CALL single_procedure()")
+        Client.com_stmt_prepare(client, "CALL single_ok_procedure()")
 
-      {:ok, resultset(num_rows: 1, status_flags: status_flags)} =
+      {:ok, ok_packet(affected_rows: 1, status_flags: status_flags)} =
         Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
 
       assert list_status_flags(status_flags) == [:server_status_autocommit]
@@ -359,7 +359,7 @@ defmodule MyXQL.ClientTest do
 
     test "with stored procedure of multiple results", %{client: client} do
       {:ok, com_stmt_prepare_ok(statement_id: statement_id)} =
-        Client.com_stmt_prepare(client, "CALL multi_procedure()")
+        Client.com_stmt_prepare(client, "CALL one_resultset_one_ok_procedure()")
 
       assert {:error, :multiple_results} =
                Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
@@ -371,12 +371,12 @@ defmodule MyXQL.ClientTest do
       {:ok, com_stmt_prepare_ok(statement_id: statement_id)} =
         Client.com_stmt_prepare(client, "CALL cursor_procedure()")
 
-      {:ok, resultset(num_rows: 1, rows: [[3]])} =
-        Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only)
+      {:ok, [ok_packet(affected_rows: 0), resultset(num_rows: 1, rows: [[3]])]} =
+        Client.com_stmt_execute(client, statement_id, [], :cursor_type_read_only, {:many, []})
 
       # This will be called if, for instance, someone issues the procedure statement from Ecto.Adapters.SQL.query
-      {:ok, resultset(num_rows: 1, rows: [[3]])} =
-        Client.com_stmt_execute(client, statement_id, [], :cursor_type_no_cursor)
+      {:ok, [ok_packet(affected_rows: 0), resultset(num_rows: 1, rows: [[3]])]} =
+        Client.com_stmt_execute(client, statement_id, [], :cursor_type_no_cursor, {:many, []})
 
       Client.com_quit(client)
     end

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -663,10 +663,10 @@ defmodule MyXQLTest do
     setup :connect
 
     test "text query", c do
-      assert %MyXQL.Result{num_rows: 1, rows: nil} =
+      assert %MyXQL.Result{rows: nil} =
                MyXQL.query!(c.conn, "CALL single_ok_procedure()", [], query_type: :text)
 
-      assert %MyXQL.Result{num_rows: 1, rows: nil} =
+      assert %MyXQL.Result{rows: nil} =
                MyXQL.query!(c.conn, "CALL single_ok_procedure()", [], query_type: :text)
 
       assert [%MyXQL.Result{rows: [[1]]}, %MyXQL.Result{num_rows: 0, rows: nil}] =
@@ -680,7 +680,7 @@ defmodule MyXQLTest do
     end
 
     test "prepared query", c do
-      assert {%MyXQL.Query{}, %MyXQL.Result{num_rows: 1, rows: nil}} =
+      assert {%MyXQL.Query{}, %MyXQL.Result{rows: nil}} =
                MyXQL.prepare_execute!(c.conn, "", "CALL single_ok_procedure()")
 
       assert {%MyXQL.Queries{},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -140,9 +140,11 @@ defmodule TestHelper do
       my_char CHAR
     );
 
-    # This will only return the trailing ok_packet
+    # This will only return the trailing ok packet
     # because the commands inside the stored procedure
-    # do not return result sets.
+    # do not return result sets. Commands inside of stored
+    # procedures that return ok packets do not have their
+    # results sent through the wire.
     DROP PROCEDURE IF EXISTS single_ok_procedure;
     DELIMITER $$
     CREATE PROCEDURE single_ok_procedure()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -140,9 +140,25 @@ defmodule TestHelper do
       my_char CHAR
     );
 
-    DROP PROCEDURE IF EXISTS single_procedure;
+    # This will only return the trailing ok_packet
+    # because the commands inside the stored procedure
+    # do not return result sets.
+    DROP PROCEDURE IF EXISTS single_ok_procedure;
     DELIMITER $$
-    CREATE PROCEDURE single_procedure()
+    CREATE PROCEDURE single_ok_procedure()
+    BEGIN
+      CREATE TABLE IF NOT EXISTS integers (x int);
+      INSERT INTO integers VALUES (10);
+      INSERT INTO integers VALUES (11);
+    END$$
+    DELIMITER ;
+
+    # This will return a single result set
+    # and a single trailing ok packet. It must
+    # be used with the query_many variants.
+    DROP PROCEDURE IF EXISTS one_resultset_one_ok_procedure;
+    DELIMITER $$
+    CREATE PROCEDURE one_resultset_one_ok_procedure()
     BEGIN
       SELECT 1;
     END$$


### PR DESCRIPTION
This ticket is addressing the issue reported here: https://github.com/elixir-ecto/myxql/issues/151.

The underlying problem is that DDL commands return `ok_packet` results and these were not being considered when collecting the results in `MyXQL.Connection.result`. While investigating this I noticed some other cases that can cause issues:

1. Mixing statements that return `resultset` and `ok_packet` in text queries causes incorrect results. 
   - Once an `ok_packet` response is received the results are returned. Any statements coming after it will be processed by the db but the result won't be returned to the user. This means a query such as `create table; select 1;` will. only return the result for `create` and not for the `select`.
   - A trailing `ok_packet` from a stored procedure can be confused with other statement combinations. For instance, the following 2 queries will process the same packets:
     - A stored procedure that executes `select 1;`
     - A text query such as `select 1; create table;`
     
    The issue is that trailing ok packets from stored procedures were handled specially, being thrown away and not returned to the user. In the second query above the result from `create` will similarly be thrown away. 

    The proposal in this PR is to treat the trailing ok packet as a valid result. You can think of it as the result from the stored procedure execution. I'm not able to see another way to handle both scenarios correctly. The consequence of this is that it breaks a couple of the existing behaviours:
      - Can't use `query/4` to execute stored procedures with a single select statement in them. Need to use the query_many variant.
      - Can't use `stream/4` to execute stored procedures with a single select statement in them. 

    To avoid breaking `stream/4` without having an alternative method to perform the same action I could investigate what it would take to create `stream_many` and submit that before merging this change. Or I could see what it would take to alter the current cursor logic to allow for multiple statements, since it is already returning many (chunked) results.

2. The `query_many` variants weren't handling error packets.  To be compliant with the current DBConnection behaviour it looks like there are only 2 options: 
    - return the `%MyXQL.Error{}` struct in the list of results 
    - return `{:error,  %MyXQL.Error{}}`. 
    
    The proposal in this PR is for the latter because it seems like the only way to allow `disconnect_on_error_codes` to work. If there is a desire to change the DBConnection behaviour to accommodate returning the successful results along with the error, I could investigate that.
     