### PR TITLE
print query statement in error log

### DIFF
--- a/lib/myxql/error.ex
+++ b/lib/myxql/error.ex
@@ -14,11 +14,22 @@ defmodule MyXQL.Error do
         }
 
   @impl true
-  def message(%{mysql: %{code: code, name: nil}, message: message}) do
-    "(#{code}) " <> message
+  def message(e) do
+    if map = e.mysql do
+      IO.iodata_to_binary([
+        [?(, Integer.to_string(map.code), ?)],
+        build_name(map),
+        e.message,
+        build_query(e.statement)
+      ])
+    else
+      e.message
+    end
   end
 
-  def message(%{mysql: %{code: code, name: name}, message: message}) do
-    "(#{code}) (#{name}) " <> message
-  end
+  defp build_name(%{name: nil}), do: [?\s]
+  defp build_name(%{name: name}), do: [?\s, ?(, Atom.to_string(name), ?), ?\s]
+
+  defp build_query(nil), do: []
+  defp build_query(query_statement), do: ["\n\n    query: ", query_statement]
 end

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -218,6 +218,13 @@ defmodule MyXQLTest do
       assert Enum.to_list(columns["x"]) == [1, 2, 3]
       assert Enum.to_list(columns["y"]) == ["a", "b", "c"]
     end
+
+    test "query statement is printed in error", c do
+      {:error, e} = MyXQL.query(c.conn, "SELECT not_a_column FROM integers", [])
+      error_log = MyXQL.Error.message(e)
+      assert error_log =~ "query: SELECT not_a_column FROM integers"
+      assert error_log =~ "(1054) Unknown column"
+    end
   end
 
   describe ":prepare option" do


### PR DESCRIPTION
Adds the query statement to the error log. This is similar to the implementation from Postgrex.