### PR TITLE
Support encoding explain format=json

### DIFF
--- a/lib/myxql/protocol/values.ex
+++ b/lib/myxql/protocol/values.ex
@@ -86,6 +86,7 @@ defmodule MyXQL.Protocol.Values do
   defp column_def_to_type(column_def(type: :mysql_type_tiny_blob)), do: :binary
   defp column_def_to_type(column_def(type: :mysql_type_medium_blob)), do: :binary
   defp column_def_to_type(column_def(type: :mysql_type_long_blob)), do: :binary
+  defp column_def_to_type(column_def(name: "EXPLAIN", type: :mysql_type_var_string)), do: :json
   defp column_def_to_type(column_def(type: :mysql_type_var_string)), do: :binary
   defp column_def_to_type(column_def(type: :mysql_type_string)), do: :binary
   defp column_def_to_type(column_def(type: :mysql_type_bit, length: length)), do: {:bit, length}

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -258,6 +258,16 @@ defmodule MyXQL.Protocol.ValueTest do
         assert_roundtrip(c, "my_varbinary3", <<1, 2, 3>>)
       end
 
+      test "MYSQL_TYPE_VAR_STRING - EXPLAIN JSON", c do
+        assert %MyXQL.Result{columns: ["EXPLAIN"], num_rows: 1, rows: [[value]]} = query!(c, "EXPLAIN FORMAT=JSON SELECT 1")
+        assert is_map(value)
+      end
+
+      test "MYSQL_TYPE_VAR_STRING - EXPLAIN TRADITIONAL", c do
+        assert %MyXQL.Result{columns: cols} = query!(c, "EXPLAIN FORMAT=TRADITIONAL SELECT 1")
+        assert Enum.count(cols) > 1
+      end
+
       test "MYSQL_TYPE_VARCHAR", c do
         assert_roundtrip(c, "my_varchar3", <<1, 2, 3>>)
       end


### PR DESCRIPTION
Hi there, thanks for a great ecto adapter!

I would like to add support for encoding the result from [explain format=json](https://dev.mysql.com/doc/refman/5.7/en/explain.html) (like what postgrex can do). If this makes sense, I plan on submitting a PR to ecto_sql to expose it there as well.

I don't know if the approach here is good, feels a bit "informal" somehow. I read up on the [mysql internals column definition](https://dev.mysql.com/doc/internals/en/com-query-response.html#packet-Protocol::ColumnDefinition41) but didn't find anything that could make it a bit more strict/solid.

I basically looked at what was coming in to MyXQL.Protocol.decode_column_def and tried to distinguish between a text/traditional explain and a format=json one. 🤔 