### PR TITLE
do not use deprecated features by Elixir version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
         pair:
           - elixir: 1.11.3
             otp: 23.2.5
+          - elixir: 1.14.0
+            otp: 25.1.2
         include:
           - db: mysql:8.0
             pair:

--- a/lib/myxql/protocol/auth.ex
+++ b/lib/myxql/protocol/auth.ex
@@ -1,7 +1,7 @@
 defmodule MyXQL.Protocol.Auth do
   @moduledoc false
 
-  # TODO: remove when we require Elixir v1.14+
+  # TODO: remove when we require Elixir v1.10+
   require Bitwise
 
   # https://dev.mysql.com/doc/internals/en/secure-password-authentication.html

--- a/lib/myxql/protocol/auth.ex
+++ b/lib/myxql/protocol/auth.ex
@@ -1,7 +1,7 @@
 defmodule MyXQL.Protocol.Auth do
   @moduledoc false
 
-  # TODO: remove when we require Elixir v1.10+
+  # TODO: remove when we require Elixir v1.14+
   require Bitwise
 
   # https://dev.mysql.com/doc/internals/en/secure-password-authentication.html

--- a/lib/myxql/protocol/server_error_codes.ex
+++ b/lib/myxql/protocol/server_error_codes.ex
@@ -1,7 +1,15 @@
 defmodule MyXQL.Protocol.ServerErrorCodes do
   @moduledoc false
 
-  codes = [
+  # TODO: remove when we require Elixir v1.10+
+  codes_from_config =
+    if Version.match?(System.version(), ">= 1.10.0") do
+      Application.compile_env(:myxql, :extra_error_codes, [])
+    else
+      apply(Application, :get_env, [:myxql, :extra_error_codes, []])
+    end
+
+  default_codes = [
     {1005, :ER_CANT_CREATE_TABLE},
     {1006, :ER_CANT_CREATE_DB},
     {1007, :ER_DB_CREATE_EXISTS},
@@ -23,8 +31,7 @@ defmodule MyXQL.Protocol.ServerErrorCodes do
     {1836, :ER_READ_ONLY_MODE}
   ]
 
-  # TODO: use Application.compile_env/3 when we require Elixir v1.10
-  codes = codes ++ Application.get_env(:myxql, :extra_error_codes, [])
+  codes = default_codes ++ codes_from_config
 
   for {code, name} <- Enum.uniq(codes) do
     def name_to_code(unquote(name)), do: unquote(code)


### PR DESCRIPTION
Deprecation

- Elixir 1.14 - `use Bitwise` is deprecated
- Elixir 1.10 - `Application.compile_env/3` is introduced

Also add Elixir 1.14.1 & OTP 25.1.2 to CI