### PR TITLE
Return {status, state} on transaction error

### DIFF
--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -438,7 +438,9 @@ defmodule MyXQL.Connection do
         {:ok, result, state}
 
       other ->
-        result(other, statement, state)
+        with {:error, _exception, state} <- result(other, statement, state) do
+          {:error, state}
+        end
     end
   end
 

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -438,6 +438,9 @@ defmodule MyXQL.Connection do
         {:ok, result, state}
 
       other ->
+        # We convert {:error, exception, state} to {:error, state}
+        # so that DBConnection will disconnect during handle_begin/handle_rollback
+        # and will attempt to rollback during handle_commit
         with {:error, _exception, state} <- result(other, statement, state) do
           {:error, state}
         end


### PR DESCRIPTION
so db_connection caller will be able to execute rollback for a failed `commit` operation or disconnect a given connection for a failed `begin` or `rollback` operation.

More information in https://github.com/elixir-ecto/db_connection/issues/272