### PR TITLE
Fix: adding value 243(0xF3) as string for new versions of mysql 8.0

### DIFF
--- a/lib/myxql/protocol/values.ex
+++ b/lib/myxql/protocol/values.ex
@@ -55,7 +55,8 @@ defmodule MyXQL.Protocol.Values do
     mysql_type_newdate: 0x0E,
     mysql_type_timestamp2: 0x11,
     mysql_type_datetime2: 0x12,
-    mysql_type_date2: 0x13
+    mysql_type_date2: 0x13,
+    mysql_type_string2: 0xF3
   ]
 
   for {atom, code} <- types do


### PR DESCRIPTION
![image (12)](https://user-images.githubusercontent.com/67085781/219028458-f10b706c-0bd1-40c2-9789-31435805b8df.png)

Adding error 243 (0xF3) to library types. This PR aims to fix that issue.
