### PR TITLE
Fix encode_binary_time for ~T[00:00:00]

### DIFF
--- a/lib/myxql/protocol/values.ex
+++ b/lib/myxql/protocol/values.ex
@@ -276,10 +276,10 @@ defmodule MyXQL.Protocol.Values do
   ## Time/DateTime
 
   # MySQL supports negative time and days, we don't.
-  # See: https://dev.mysql.com/doc/internals/en/binary-protocol-value.html#packet-ProtocolBinary::MYSQL_TYPE_TIME
+  # See: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row_value_time
 
   defp encode_binary_time(%Time{hour: 0, minute: 0, second: 0, microsecond: {0, 0}}) do
-    {:mysql_type_time, <<0>>}
+    {:mysql_type_time, <<1>>}
   end
 
   defp encode_binary_time(%Time{hour: hour, minute: minute, second: second, microsecond: {0, 0}}) do

--- a/test/myxql/protocol/values_test.exs
+++ b/test/myxql/protocol/values_test.exs
@@ -109,6 +109,18 @@ defmodule MyXQL.Protocol.ValueTest do
         assert insert_and_get(c, "my_time", ~T[09:10:20.123]) == ~T[09:10:20]
       end
 
+      test "MYSQL_TYPE_TIME - should pass examples from https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html#sect_protocol_binary_resultset_row_value_time",
+           c do
+        assert_roundtrip(c, "my_time6", ~T[19:27:30.000001])
+        assert insert_and_get(c, "my_time6", ~T[19:27:30.000001]) == ~T[19:27:30.000001]
+
+        assert_roundtrip(c, "my_time", ~T[19:27:30])
+        assert insert_and_get(c, "my_time", ~T[19:27:30]) == ~T[19:27:30]
+
+        assert_roundtrip(c, "my_time", ~T[00:00:00])
+        assert insert_and_get(c, "my_time", ~T[00:00:00]) == ~T[00:00:00]
+      end
+
       if @protocol == :binary do
         test "MYSQL_TYPE_TIME - negative time", c do
           assert_raise ArgumentError, ~r"cannot decode \"-01:00:00\" as time", fn ->


### PR DESCRIPTION
As pointed out in https://github.com/elixir-ecto/ecto/issues/4045 then let's take a closer look at the examples for `MYSQL_TYPE_TIME` from: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_binary_resultset.html

```code
0c 01 78 00 00 00 13 1b 1e 01 00 00 00 -- time  -120d 19:27:30.000 001
08 01 78 00 00 00 13 1b 1e             -- time  -120d 19:27:30
01                                     -- time     0d 00:00:00
```

We see three hexadecimal encoded packets that we can decode in Elixir with `Base.decode16!(packet, case: :lower)`; by decoding the last packet, which represents the most compressed packet we can send, then we can see it differs from what the adapter returns: `<<0>>`.

```elixir
iex> Base.decode16!("01")
<<1>>
```

Returning the correct packet from the example will work for all tested CI versions except mysql:8.0, which returns.

```
** (MyXQL.Error) (1835) Malformed communication packet.
```


> Premature optimization is the root of all evil

Famously said by [Donald Knuth](https://en.wikipedia.org/wiki/Donald_Knuth).

To ensure that the adapter will work on most versions and systems, we can avoid this optimization for `~T[00:00:00]` at the low cost of 8 extra bytes by sending the packet in its entirety.