### PR TITLE
Filter client capabilities that can't be met by server

### DIFF
--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -184,10 +184,10 @@ defmodule MyXQL.Protocol do
     if config.ssl? && !has_capability_flag?(server_capability_flags, :client_ssl) do
       {:error, :server_does_not_support_ssl}
     else
-      with client_capability_flags <-
-             filter_capabilities(server_capability_flags, client_capability_flags) do
-        {:ok, client_capability_flags}
-      end
+      client_capability_flags =
+        filter_capabilities(server_capability_flags, client_capability_flags)
+
+      {:ok, client_capability_flags}
     end
   end
 

--- a/lib/myxql/protocol/flags.ex
+++ b/lib/myxql/protocol/flags.ex
@@ -34,6 +34,8 @@ defmodule MyXQL.Protocol.Flags do
 
   def has_capability_flag?(flags, name), do: has_flag?(@capability_flags, flags, name)
 
+  def remove_capability_flag(flags, name), do: remove_flag(@capability_flags, flags, name)
+
   def put_capability_flags(flags \\ 0, names), do: put_flags(@capability_flags, flags, names)
 
   def list_capability_flags(flags), do: list_flags(@capability_flags, flags)
@@ -91,6 +93,11 @@ defmodule MyXQL.Protocol.Flags do
 
   defp put_flags(all_flags, flags, names) do
     Enum.reduce(names, flags, &(&2 ||| Keyword.fetch!(all_flags, &1)))
+  end
+
+  defp remove_flag(all_flags, flags, name) do
+    value = Keyword.fetch!(all_flags, name)
+    flags &&& ~~~value
   end
 
   def list_flags(all_flags, flags) do


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/myxql/issues/173

Previously, during the initial handshake the library would error if the client and server capabilities didn't match. However, the MySQL spec says the client should simply remove the flags the server can't comply with: https://dev.mysql.com/doc/dev/mysql-server/latest/page_protocol_connection_phase.html.

It seems this part of the code was reusing a function that tried to ensure all the appropriate auth capabilities were present: https://github.com/elixir-ecto/myxql/blob/master/lib/myxql/protocol.ex#L116.

The change here is to introduce a filtering function instead of using the "ensure everything allowed" function.