### PR TITLE
Enable cleartext plugin

### DIFF
--- a/lib/myxql.ex
+++ b/lib/myxql.ex
@@ -23,6 +23,7 @@ defmodule MyXQL do
           | {:ping_timeout, timeout()}
           | {:prepare, :force_named | :named | :unnamed}
           | {:disconnect_on_error_codes, [atom()]}
+          | {:enable_cleartext_plugin, boolean()}
           | DBConnection.start_option()
 
   @type option() :: DBConnection.option()
@@ -99,6 +100,8 @@ defmodule MyXQL do
     * `:disconnect_on_error_codes` - List of error code integers or atoms that when encountered
       will disconnect the connection. See "Disconnecting on Errors" section below for more
       information.
+
+    * `:enable_cleartext_plugin` - Set to `true` to send password as cleartext (default: `false`)
 
    The given options are passed down to DBConnection, some of the most commonly used ones are
    documented below:

--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -25,7 +25,8 @@ defmodule MyXQL.Client do
       :socket_options,
       :max_packet_size,
       :charset,
-      :collation
+      :collation,
+      :enable_cleartext_plugin
     ]
 
     def new(opts) do
@@ -45,7 +46,8 @@ defmodule MyXQL.Client do
         socket_options:
           Keyword.merge([mode: :binary, packet: :raw, active: false], opts[:socket_options] || []),
         charset: Keyword.get(opts, :charset),
-        collation: Keyword.get(opts, :collation)
+        collation: Keyword.get(opts, :collation),
+        enable_cleartext_plugin: Keyword.get(opts, :enable_cleartext_plugin, false)
       }
     end
 

--- a/lib/myxql/protocol/auth.ex
+++ b/lib/myxql/protocol/auth.ex
@@ -33,6 +33,9 @@ defmodule MyXQL.Protocol.Auth do
       config.password == nil ->
         ""
 
+      auth_plugin_name == "mysql_clear_password" and config.enable_cleartext_plugin ->
+        config.password <> <<0>>
+
       auth_plugin_name == "mysql_native_password" ->
         mysql_native_password(config.password, initial_auth_plugin_data)
 

--- a/lib/myxql/protocol/types.ex
+++ b/lib/myxql/protocol/types.ex
@@ -66,6 +66,8 @@ defmodule MyXQL.Protocol.Types do
     string
   end
 
+  def take_string_nul(""), do: {nil, ""}
+
   def take_string_nul(binary) do
     [string, rest] = :binary.split(binary, <<0>>)
     {string, rest}

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -156,7 +156,9 @@ defmodule MyXQLTest do
 
       test "#{@protocol}: query with multiple rows", c do
         %MyXQL.Result{num_rows: 2} =
-          MyXQL.query!(c.conn, "INSERT INTO integers VALUES (10), (20)", [], query_type: @protocol)
+          MyXQL.query!(c.conn, "INSERT INTO integers VALUES (10), (20)", [],
+            query_type: @protocol
+          )
 
         assert {:ok, %MyXQL.Result{columns: ["x"], rows: [[10], [20]]}} =
                  MyXQL.query(c.conn, "SELECT * FROM integers")
@@ -168,7 +170,9 @@ defmodule MyXQLTest do
         values = Enum.map_join(1..num, ", ", &"(#{&1})")
 
         result =
-          MyXQL.query!(c.conn, "INSERT INTO integers VALUES " <> values, [], query_type: @protocol)
+          MyXQL.query!(c.conn, "INSERT INTO integers VALUES " <> values, [],
+            query_type: @protocol
+          )
 
         assert result.num_rows == num
 


### PR DESCRIPTION
Took me a minute to figure out why my app kept crashing in ECS :smile:

RDS IAM auth requires the generated auth token to be send as a cleartext password with MySQL. I'm replicating how [mysql-client](https://dev.mysql.com/doc/refman/8.0/en/cleartext-pluggable-authentication.html) enables  cleartext password in this PR.

There wasn't a way to integrate the tests with actual MySQL containers, since all plugins that support cleartext are in the enterprise edition, so I'm mocking the responses after introspecting mysql packets.

I'm currently using this branch in AWS.