### PR TITLE
Update show warnings example to use text protocol

### DIFF
--- a/lib/myxql/result.ex
+++ b/lib/myxql/result.ex
@@ -18,7 +18,7 @@ defmodule MyXQL.Result do
   If `result.num_warnings` is non-zero it means there were warnings and they can be
   retrieved by making another query:
 
-      MyXQL.query!(conn, "SHOW WARNINGS")
+      MyXQL.query!(conn, "SHOW WARNINGS", [], query_type: :text)
 
   """
 


### PR DESCRIPTION
When I was attempting to see the warnings from a query I got this error using the binary protocol:

```elixir
** (MyXQL.Error) (1295) (ER_UNSUPPORTED_PS) This command is not supported in the prepared statement protocol yet
     
         query: SHOW WARNINGS
```