### PR TITLE
add MySQL 8 check constraint error number

### DIFF
--- a/lib/myxql/protocol/server_error_codes.ex
+++ b/lib/myxql/protocol/server_error_codes.ex
@@ -28,7 +28,8 @@ defmodule MyXQL.Protocol.ServerErrorCodes do
     {1452, :ER_NO_REFERENCED_ROW_2},
     {1461, :ER_MAX_PREPARED_STMT_COUNT_REACHED},
     {1792, :ER_CANT_EXECUTE_IN_READ_ONLY_TRANSACTION},
-    {1836, :ER_READ_ONLY_MODE}
+    {1836, :ER_READ_ONLY_MODE},
+    {3819, :ER_CHECK_CONSTRAINT_VIOLATED}
   ]
 
   codes = default_codes ++ codes_from_config


### PR DESCRIPTION
fixes https://github.com/elixir-ecto/myxql/issues/186
allows passing the `ER_CHECK_CONSTRAINT_VIOLATED` name for `MyXQL.Error`

https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html#error_er_check_constraint_violated