### PR TITLE
Make non preparable statement test compatible with future mariadb

### DIFF
--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -142,17 +142,17 @@ defmodule MyXQLTest do
       log = &send(self, &1)
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "BEGIN", [], query_type: :text, log: log)
+               MyXQL.query(c.conn, "PREPARE", [], query_type: :text, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.TextQuery{}}
 
       assert {:error, %MyXQL.Error{mysql: %{code: 1295}}} =
-               MyXQL.query(c.conn, "BEGIN", [], query_type: :binary, log: log)
+               MyXQL.query(c.conn, "PREPARE", [], query_type: :binary, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "BEGIN", [], query_type: :binary_then_text, log: log)
+               MyXQL.query(c.conn, "PREPARE", [], query_type: :binary_then_text, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
     end

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -142,17 +142,17 @@ defmodule MyXQLTest do
       log = &send(self, &1)
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "PREPARE", [], query_type: :text, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT VALUES (?)';", [], query_type: :text, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.TextQuery{}}
 
       assert {:error, %MyXQL.Error{mysql: %{code: 1295}}} =
-               MyXQL.query(c.conn, "PREPARE", [], query_type: :binary, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT VALUES (?)'", [], query_type: :binary, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "PREPARE", [], query_type: :binary_then_text, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT VALUES (?)'", [], query_type: :binary_then_text, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
     end

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -176,7 +176,9 @@ defmodule MyXQLTest do
 
       test "#{@protocol}: query with multiple rows", c do
         %MyXQL.Result{num_rows: 2} =
-          MyXQL.query!(c.conn, "INSERT INTO integers VALUES (10), (20)", [], query_type: @protocol)
+          MyXQL.query!(c.conn, "INSERT INTO integers VALUES (10), (20)", [],
+            query_type: @protocol
+          )
 
         assert {:ok, %MyXQL.Result{columns: ["x"], rows: [[10], [20]]}} =
                  MyXQL.query(c.conn, "SELECT * FROM integers")
@@ -188,7 +190,9 @@ defmodule MyXQLTest do
         values = Enum.map_join(1..num, ", ", &"(#{&1})")
 
         result =
-          MyXQL.query!(c.conn, "INSERT INTO integers VALUES " <> values, [], query_type: @protocol)
+          MyXQL.query!(c.conn, "INSERT INTO integers VALUES " <> values, [],
+            query_type: @protocol
+          )
 
         assert result.num_rows == num
 

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -142,17 +142,26 @@ defmodule MyXQLTest do
       log = &send(self, &1)
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [], query_type: :text, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [],
+                 query_type: :text,
+                 log: log
+               )
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.TextQuery{}}
 
       assert {:error, %MyXQL.Error{mysql: %{code: 1295}}} =
-               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [], query_type: :binary, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [],
+                 query_type: :binary,
+                 log: log
+               )
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [], query_type: :binary_then_text, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [],
+                 query_type: :binary_then_text,
+                 log: log
+               )
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
     end
@@ -167,9 +176,7 @@ defmodule MyXQLTest do
 
       test "#{@protocol}: query with multiple rows", c do
         %MyXQL.Result{num_rows: 2} =
-          MyXQL.query!(c.conn, "INSERT INTO integers VALUES (10), (20)", [],
-            query_type: @protocol
-          )
+          MyXQL.query!(c.conn, "INSERT INTO integers VALUES (10), (20)", [], query_type: @protocol)
 
         assert {:ok, %MyXQL.Result{columns: ["x"], rows: [[10], [20]]}} =
                  MyXQL.query(c.conn, "SELECT * FROM integers")
@@ -181,9 +188,7 @@ defmodule MyXQLTest do
         values = Enum.map_join(1..num, ", ", &"(#{&1})")
 
         result =
-          MyXQL.query!(c.conn, "INSERT INTO integers VALUES " <> values, [],
-            query_type: @protocol
-          )
+          MyXQL.query!(c.conn, "INSERT INTO integers VALUES " <> values, [], query_type: @protocol)
 
         assert result.num_rows == num
 

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -142,17 +142,17 @@ defmodule MyXQLTest do
       log = &send(self, &1)
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT VALUES (?)';", [], query_type: :text, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [], query_type: :text, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.TextQuery{}}
 
       assert {:error, %MyXQL.Error{mysql: %{code: 1295}}} =
-               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT VALUES (?)'", [], query_type: :binary, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [], query_type: :binary, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
 
       assert {:ok, %MyXQL.Result{}} =
-               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT VALUES (?)'", [], query_type: :binary_then_text, log: log)
+               MyXQL.query(c.conn, "PREPARE prepared_stmt FROM 'SELECT 1';", [], query_type: :binary_then_text, log: log)
 
       assert_receive %DBConnection.LogEntry{query: %MyXQL.Query{}}
     end


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/myxql/issues/190

Based on [this update](https://mariadb.com/kb/en/prepare-statement/#permitted-statements), it seems fewer statements are not able to be prepared. I just changed it to one that still cannot be prepared. 