### PR TITLE
Handle insert/update/delete responses in query_many

### DIFF
--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -347,7 +347,7 @@ defmodule MyXQL.Connection do
          ),
          state
        ) do
-    columns = Enum.map(column_defs, &elem(&1, 1))
+    columns = Enum.map(column_defs, &column_def(&1, :name))
 
     %Result{
       connection_id: state.client.connection_id,

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -288,7 +288,7 @@ defmodule MyXQL.Connection do
       Enum.reduce(results, {[], nil}, fn
         result, {results, latest_status_flags} ->
           # Keep status flags from the last query. The results are given
-          # this function in reverse order, so it is the first one.
+          # to this function in reverse order, so it is the first one.
           if latest_status_flags do
             {[format_result(result, state) | results], latest_status_flags}
           else

--- a/lib/myxql/connection.ex
+++ b/lib/myxql/connection.ex
@@ -275,93 +275,25 @@ defmodule MyXQL.Connection do
 
   ## Internals
 
-  defp result(
-         {:ok,
-          ok_packet(
-            last_insert_id: last_insert_id,
-            affected_rows: affected_rows,
-            status_flags: status_flags,
-            num_warnings: num_warnings
-          )},
-         query,
-         state
-       ) do
-    result = %Result{
-      connection_id: state.client.connection_id,
-      last_insert_id: last_insert_id,
-      num_rows: affected_rows,
-      num_warnings: num_warnings
-    }
-
-    {:ok, query, result, put_status(state, status_flags)}
+  defp result({:ok, ok_packet(status_flags: status_flags) = result}, query, state) do
+    {:ok, query, format_result(result, state), put_status(state, status_flags)}
   end
 
-  defp result(
-         {:ok,
-          resultset(
-            column_defs: column_defs,
-            num_rows: num_rows,
-            rows: rows,
-            status_flags: status_flags,
-            num_warnings: num_warnings
-          )},
-         query,
-         state
-       ) do
-    columns = Enum.map(column_defs, &elem(&1, 1))
-
-    result = %Result{
-      connection_id: state.client.connection_id,
-      columns: columns,
-      num_rows: num_rows,
-      rows: rows,
-      num_warnings: num_warnings
-    }
-
-    {:ok, query, result, put_status(state, status_flags)}
+  defp result({:ok, resultset(status_flags: status_flags) = result}, query, state) do
+    {:ok, query, format_result(result, state), put_status(state, status_flags)}
   end
 
-  defp result({:ok, resultsets}, query, state) when is_list(resultsets) do
+  defp result({:ok, results}, query, state) when is_list(results) do
     {results, status_flags} =
-      Enum.reduce(resultsets, {[], nil}, fn resultset, {results, newest_status_flags} ->
-        {result, status_flags} =
-          case resultset do
-            resultset(
-              column_defs: column_defs,
-              num_rows: num_rows,
-              rows: rows,
-              status_flags: status_flags,
-              num_warnings: num_warnings
-            ) ->
-              {%Result{
-                 connection_id: state.client.connection_id,
-                 columns: Enum.map(column_defs, &elem(&1, 1)),
-                 num_rows: num_rows,
-                 rows: rows,
-                 num_warnings: num_warnings
-               }, status_flags}
-
-            ok_packet(
-              last_insert_id: last_insert_id,
-              affected_rows: affected_rows,
-              status_flags: status_flags,
-              num_warnings: num_warnings
-            ) ->
-              {%Result{
-                 connection_id: state.client.connection_id,
-                 last_insert_id: last_insert_id,
-                 num_rows: affected_rows,
-                 num_warnings: num_warnings
-               }, status_flags}
+      Enum.reduce(results, {[], nil}, fn
+        result, {results, latest_status_flags} ->
+          # Keep status flags from the last query. The results are given
+          # this function in reverse order, so it is the first one.
+          if latest_status_flags do
+            {[format_result(result, state) | results], latest_status_flags}
+          else
+            {[format_result(result, state) | results], status_flags(result)}
           end
-
-        # Keep status flags from the last query. The resultsets
-        # are given to this function in reverse order, so it is the first one.
-        if newest_status_flags do
-          {[result | results], newest_status_flags}
-        else
-          {[result | results], status_flags}
-        end
       end)
 
     {:ok, query, results, put_status(state, status_flags)}
@@ -389,6 +321,45 @@ defmodule MyXQL.Connection do
     message = "(#{address}) #{format_reason(reason)} - #{inspect(reason)}"
     {:error, %DBConnection.ConnectionError{message: message}}
   end
+
+  defp format_result(
+         ok_packet(
+           last_insert_id: last_insert_id,
+           affected_rows: affected_rows,
+           num_warnings: num_warnings
+         ),
+         state
+       ) do
+    %Result{
+      connection_id: state.client.connection_id,
+      last_insert_id: last_insert_id,
+      num_rows: affected_rows,
+      num_warnings: num_warnings
+    }
+  end
+
+  defp format_result(
+         resultset(
+           column_defs: column_defs,
+           num_rows: num_rows,
+           rows: rows,
+           num_warnings: num_warnings
+         ),
+         state
+       ) do
+    columns = Enum.map(column_defs, &elem(&1, 1))
+
+    %Result{
+      connection_id: state.client.connection_id,
+      columns: columns,
+      num_rows: num_rows,
+      rows: rows,
+      num_warnings: num_warnings
+    }
+  end
+
+  defp status_flags(ok_packet(status_flags: status_flags)), do: status_flags
+  defp status_flags(resultset(status_flags: status_flags)), do: status_flags
 
   defp error(reason, %{statement: statement}, state) do
     error(reason, statement, state)

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -208,6 +208,15 @@ defmodule MyXQLTest do
 
       assert {:ok, [%MyXQL.Result{rows: [[1]]}]} =
                MyXQL.query_many(c.conn, "SELECT 1;", [], query_type: :text)
+
+      assert {:ok, [%MyXQL.Result{num_rows: 1}]} =
+               MyXQL.query_many(c.conn, "INSERT INTO integers VALUES (1);", [], query_type: :text)
+
+      assert {:ok, [%MyXQL.Result{num_rows: 0}]} =
+               MyXQL.query_many(c.conn, "UPDATE integers SET x = x + 1 WHERE x = 0;", [], query_type: :text)
+
+      assert {:ok, [%MyXQL.Result{num_rows: 1}]} =
+               MyXQL.query_many(c.conn, "DELETE FROM integers WHERE x = 1;", [], query_type: :text)
     end
 
     test "query_many!/4 with text", c do

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -213,10 +213,14 @@ defmodule MyXQLTest do
                MyXQL.query_many(c.conn, "INSERT INTO integers VALUES (1);", [], query_type: :text)
 
       assert {:ok, [%MyXQL.Result{num_rows: 0}]} =
-               MyXQL.query_many(c.conn, "UPDATE integers SET x = x + 1 WHERE x = 0;", [], query_type: :text)
+               MyXQL.query_many(c.conn, "UPDATE integers SET x = x + 1 WHERE x = 0;", [],
+                 query_type: :text
+               )
 
       assert {:ok, [%MyXQL.Result{num_rows: 1}]} =
-               MyXQL.query_many(c.conn, "DELETE FROM integers WHERE x = 1;", [], query_type: :text)
+               MyXQL.query_many(c.conn, "DELETE FROM integers WHERE x = 1;", [],
+                 query_type: :text
+               )
     end
 
     test "query_many!/4 with text", c do

--- a/test/myxql_test.exs
+++ b/test/myxql_test.exs
@@ -209,15 +209,15 @@ defmodule MyXQLTest do
       assert {:ok, [%MyXQL.Result{rows: [[1]]}]} =
                MyXQL.query_many(c.conn, "SELECT 1;", [], query_type: :text)
 
-      assert {:ok, [%MyXQL.Result{num_rows: 1}]} =
+      assert {:ok, [%MyXQL.Result{num_rows: 1, columns: nil}]} =
                MyXQL.query_many(c.conn, "INSERT INTO integers VALUES (1);", [], query_type: :text)
 
-      assert {:ok, [%MyXQL.Result{num_rows: 0}]} =
+      assert {:ok, [%MyXQL.Result{num_rows: 0, columns: nil}]} =
                MyXQL.query_many(c.conn, "UPDATE integers SET x = x + 1 WHERE x = 0;", [],
                  query_type: :text
                )
 
-      assert {:ok, [%MyXQL.Result{num_rows: 1}]} =
+      assert {:ok, [%MyXQL.Result{num_rows: 1, columns: nil}]} =
                MyXQL.query_many(c.conn, "DELETE FROM integers WHERE x = 1;", [],
                  query_type: :text
                )


### PR DESCRIPTION
Closes https://github.com/elixir-ecto/myxql/issues/193

There are still a lot of other weird situations where query_many will break, [see here](https://github.com/elixir-ecto/myxql/pull/152/files). But this will fix the use case in the issue. If there is interest, we can continue fixing query_many completely but I need some time to play with the old PR to understand what was happening.