### PR TITLE
permit geo ~> V4.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule MyXQL.MixProject do
       {:db_connection, "~> 2.4.1 or ~> 2.5", db_connection_opts()},
       {:decimal, "~> 1.6 or ~> 2.0"},
       {:jason, "~> 1.0", optional: true},
-      {:geo, "~> 3.4", optional: true},
+      {:geo, "~> 3.4 or ~> 4.0", optional: true},
       {:table, "~> 0.1.0", optional: true},
       {:binpp, ">= 0.0.0", only: [:dev, :test]},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},


### PR DESCRIPTION
Relax the Geo dependency so we can use this lib with Geo ~> V4.0.