### PR TITLE
Add MySQL 8.4 to CI and make the test suite 8.4-compatible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - mysql:5.6
           - mysql:5.7
           - mysql:8.0
+          - mysql:8.4
           - mariadb:10.3
         pair:
           - elixir: 1.13

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,13 @@ services:
     environment:
       - MYSQL_ALLOW_EMPTY_PASSWORD=1
     command: "--default-authentication-plugin=sha256_password"
+  mysql-8.4:
+    image: "mysql:8.4"
+    ports:
+      - "8400:3306"
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=1
+    command: "--innodb_log_file_size=1G"
   mariadb-10.3:
     image: "mariadb:10.3"
     ports:

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -190,8 +190,12 @@ defmodule TestHelper do
   end
 
   def available_auth_plugins do
+    # MySQL 8.4 ships `mysql_native_password` but disables it by default, so it
+    # is still listed here with plugin_status = 'DISABLED'. Only report plugins
+    # that are actually usable (ACTIVE) so their tests get excluded otherwise.
     sql =
-      "SELECT plugin_name FROM information_schema.plugins WHERE plugin_type = 'authentication'"
+      "SELECT plugin_name FROM information_schema.plugins " <>
+        "WHERE plugin_type = 'authentication' AND plugin_status = 'ACTIVE'"
 
     for %{"plugin_name" => plugin_name} <- mysql!(sql) do
       String.to_atom(plugin_name)
@@ -199,7 +203,19 @@ defmodule TestHelper do
   end
 
   def supports_ssl? do
-    mysql!("SELECT @@have_ssl") == [%{"@@have_ssl" => "YES"}]
+    # MySQL 8.4 removed the `have_ssl` system variable, so fall back to the
+    # performance_schema (available since MySQL 8.0.16) when it is missing.
+    case mysql("SELECT @@have_ssl") do
+      {:ok, result} ->
+        result == [%{"@@have_ssl" => "YES"}]
+
+      {:error, _} ->
+        sql =
+          "SELECT VALUE FROM performance_schema.tls_channel_status " <>
+            "WHERE channel = 'mysql_main' AND property = 'Enabled'"
+
+        match?([%{"VALUE" => "Yes"}], mysql!(sql))
+    end
   end
 
   def supports_public_key_exchange? do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -190,9 +190,6 @@ defmodule TestHelper do
   end
 
   def available_auth_plugins do
-    # MySQL 8.4 ships `mysql_native_password` but disables it by default, so it
-    # is still listed here with plugin_status = 'DISABLED'. Only report plugins
-    # that are actually usable (ACTIVE) so their tests get excluded otherwise.
     sql =
       "SELECT plugin_name FROM information_schema.plugins " <>
         "WHERE plugin_type = 'authentication' AND plugin_status = 'ACTIVE'"


### PR DESCRIPTION
# Add MySQL 8.4 to CI and make the test suite 8.4-compatible

Refs #211.

## Summary

MyXQL itself already connects to MySQL 8.4 — I verified `caching_sha2_password`
(fast-auth and full RSA public-key exchange over plaintext), `sha256_password`,
and TLS all authenticate successfully against `mysql:8.4.10` using the current
release. What was missing was **CI coverage** for 8.4, and the test suite did
not run there because of two 8.4 changes:

1. **`have_ssl` system variable removed.** `TestHelper.supports_ssl?/0` queried
   `SELECT @@have_ssl`, which raises `ER_UNKNOWN_SYSTEM_VARIABLE` on 8.4 and
   aborts the whole suite during setup. It now falls back to
   `performance_schema.tls_channel_status` (available since MySQL 8.0.16) when
   the variable is missing. Older servers (5.6/5.7/8.0, MariaDB) keep using
   `@@have_ssl`.

2. **`mysql_native_password` disabled by default.** The plugin still appears in
   `information_schema.plugins`, but with `plugin_status = 'DISABLED'`, so
   `TestHelper.available_auth_plugins/0` reported it as available and the
   `mysql_native_password`-tagged tests ran and failed with "Access denied"
   instead of being excluded. The query now filters to `plugin_status = 'ACTIVE'`.

## Changes

- `.github/workflows/ci.yml`: add `mysql:8.4` to the test matrix.
- `docker-compose.yml`: add a `mysql-8.4` service (port 8400) for local runs.
- `test/test_helper.exs`: 8.4-compatible `supports_ssl?/0` and
  `available_auth_plugins/0` (both backward-compatible with older servers).

## Verification

Ran the full suite against a local `mysql:8.4.10` container. All auth/client
tests pass; `mysql_native_password` tests are correctly excluded. (The only
failures locally were the UNIX-domain-socket tests, which fail solely because
Docker Desktop for macOS cannot pass a bind-mounted socket across the VM
boundary — the `mysql` CLI can't reach it either; these pass in Linux CI, which
mounts `/var/run/mysqld`.)

## Note on the original report (#211)

The reported `1251` error is not reproducible against a stock 8.4 server with a
`caching_sha2_password` account — that combination connects fine. `1251`
(`ER_NOT_SUPPORTED_AUTH_MODE`) together with a working `mysql` CLI points to a
server-side account still bound to the now-disabled `mysql_native_password`
plugin (or an equivalent RDS parameter-group configuration), rather than a
client defect. This PR adds the 8.4 coverage that confirms the supported auth
plugins work; a separate follow-up on the reporter's specific account
configuration may still be warranted.