### PR TITLE
Fix caching_sha2_password scramble byte order

### DIFF
--- a/lib/myxql/client.ex
+++ b/lib/myxql/client.ex
@@ -195,6 +195,27 @@ defmodule MyXQL.Client do
     send_data(client, data)
   end
 
+  # Like send_recv_packet/4, but transparently consumes the OK/ERR packet that
+  # trails a caching_sha2_password fast auth success. recv_packet/3 discards any
+  # packet following the one it decodes, which would leave that OK in the
+  # socket and desync every subsequent exchange.
+  defp send_recv_auth_packet(client, payload, sequence_id) do
+    with :ok <- send_packet(client, payload, sequence_id) do
+      recv_auth_packet(client)
+    end
+  end
+
+  defp recv_auth_packet(client) do
+    decoder = fn payload, _next_packet, _state ->
+      case decode_auth_response(payload) do
+        :fast_auth_success -> {:cont, nil}
+        other -> {:halt, other}
+      end
+    end
+
+    recv_packets(client, decoder, nil, :single)
+  end
+
   def send_data(%{sock: {sock_mod, sock}}, data) do
     sock_mod.send(sock, data)
   end
@@ -459,11 +480,11 @@ defmodule MyXQL.Client do
 
     payload = encode_handshake_response_41(handshake_response)
 
-    case send_recv_packet(client, payload, &decode_auth_response/1, sequence_id) do
+    case send_recv_auth_packet(client, payload, sequence_id) do
       {:ok, auth_switch_request(plugin_name: auth_plugin_name, plugin_data: auth_plugin_data)} ->
         auth_response = Auth.auth_response(config, auth_plugin_name, auth_plugin_data)
 
-        case send_recv_packet(client, auth_response, &decode_auth_response/1, sequence_id + 2) do
+        case send_recv_auth_packet(client, auth_response, sequence_id + 2) do
           {:ok, :full_auth} ->
             perform_full_auth(client, config, auth_plugin_name, auth_plugin_data, sequence_id + 2)
 
@@ -505,7 +526,7 @@ defmodule MyXQL.Client do
 
   defp perform_public_key_auth(client, password, public_key, auth_plugin_data, sequence_id) do
     auth_response = Auth.encrypt_sha_password(password, public_key, auth_plugin_data)
-    send_recv_packet(client, auth_response, &decode_auth_response/1, sequence_id)
+    send_recv_auth_packet(client, auth_response, sequence_id)
   end
 
   defp perform_full_auth(client, config, "caching_sha2_password", auth_plugin_data, sequence_id) do
@@ -517,7 +538,7 @@ defmodule MyXQL.Client do
         <<2>>
       end
 
-    case send_recv_packet(client, auth_response, &decode_auth_response/1, sequence_id + 2) do
+    case send_recv_auth_packet(client, auth_response, sequence_id + 2) do
       {:ok, auth_more_data(data: public_key)} ->
         perform_public_key_auth(
           client,

--- a/lib/myxql/protocol.ex
+++ b/lib/myxql/protocol.ex
@@ -243,6 +243,12 @@ defmodule MyXQL.Protocol do
     decode_err_packet_body(rest)
   end
 
+  # caching_sha2_password: the scramble matched the server-side cache entry, an
+  # OK (or ERR) packet follows.
+  def decode_auth_response(<<0x01, 0x03>>) do
+    :fast_auth_success
+  end
+
   def decode_auth_response(<<0x01, 0x04>>) do
     :full_auth
   end

--- a/lib/myxql/protocol/auth.ex
+++ b/lib/myxql/protocol/auth.ex
@@ -10,9 +10,21 @@ defmodule MyXQL.Protocol.Auth do
     sha_hash(:sha, password, auth_plugin_data)
   end
 
-  @spec sha256_password(binary(), binary()) :: binary()
-  def sha256_password(password, auth_plugin_data) do
-    sha_hash(:sha256, password, auth_plugin_data)
+  # https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html
+  #
+  # Note the nonce is appended _after_ the double hash here, whereas
+  # mysql_native_password prepends it. Getting this backwards still connects
+  # against MySQL (the server falls back to the full authentication exchange),
+  # but fails outright once the server has a cached entry for the account, and
+  # against proxies such as ProxySQL that verify the scramble eagerly.
+  @spec caching_sha2_password(binary(), binary()) :: binary()
+  def caching_sha2_password(password, auth_plugin_data) do
+    password_sha = :crypto.hash(:sha256, password)
+
+    bxor_binary(
+      password_sha,
+      :crypto.hash(:sha256, :crypto.hash(:sha256, password_sha) <> auth_plugin_data)
+    )
   end
 
   def encrypt_sha_password(password, public_key, auth_plugin_data) do
@@ -47,7 +59,7 @@ defmodule MyXQL.Protocol.Auth do
         end
 
       auth_plugin_name == "caching_sha2_password" ->
-        sha256_password(config.password, initial_auth_plugin_data)
+        caching_sha2_password(config.password, initial_auth_plugin_data)
     end
   end
 

--- a/test/myxql/client_test.exs
+++ b/test/myxql/client_test.exs
@@ -155,6 +155,19 @@ defmodule MyXQL.ClientTest do
       Client.com_quit(client)
     end
 
+    # The first connection populates the server-side cache, so the second one
+    # is answered with fast auth success rather than a full auth exchange.
+    @tag caching_sha2_password: true, public_key_exchange: true
+    test "caching_sha2_password (cached, fast auth)" do
+      opts = [username: "caching_sha2_password", password: "secret"] ++ @opts
+      assert {:ok, client} = Client.connect(opts)
+      Client.com_quit(client)
+
+      assert {:ok, client} = Client.connect(opts)
+      assert {:ok, _} = Client.com_ping(client, 5000)
+      Client.com_quit(client)
+    end
+
     @tag caching_sha2_password: true, ssl: true
     test "caching_sha2_password (ssl)" do
       opts = [username: "caching_sha2_password", password: "secret"] ++ @opts_with_ssl

--- a/test/myxql/protocol/auth_test.exs
+++ b/test/myxql/protocol/auth_test.exs
@@ -1,0 +1,48 @@
+defmodule MyXQL.Protocol.AuthTest do
+  use ExUnit.Case, async: true
+
+  alias MyXQL.Protocol.Auth
+
+  @nonce <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20>>
+
+  describe "mysql_native_password/2" do
+    test "scrambles with the nonce prepended to the double hash" do
+      # XOR(SHA1(password), SHA1(nonce <> SHA1(SHA1(password))))
+      sha = :crypto.hash(:sha, "secret")
+
+      expected =
+        :crypto.exor(sha, :crypto.hash(:sha, @nonce <> :crypto.hash(:sha, sha)))
+
+      assert Auth.mysql_native_password("secret", @nonce) == expected
+      assert Base.encode16(expected, case: :lower) == "b32bb3a583e1340c0a1108d58b1be49781ad8c2f"
+    end
+  end
+
+  describe "caching_sha2_password/2" do
+    test "scrambles with the nonce appended to the double hash" do
+      # XOR(SHA256(password), SHA256(SHA256(SHA256(password)) <> nonce))
+      sha = :crypto.hash(:sha256, "secret")
+
+      expected =
+        :crypto.exor(sha, :crypto.hash(:sha256, :crypto.hash(:sha256, sha) <> @nonce))
+
+      assert Auth.caching_sha2_password("secret", @nonce) == expected
+
+      assert Base.encode16(expected, case: :lower) ==
+               "746ebe205d56a0707acb3e796e834e0dd7b1d61743b26bd5202c7a623230c7c9"
+    end
+
+    # Regression: caching_sha2_password used to reuse the mysql_native_password
+    # helper, which prepends the nonce instead of appending it. MySQL hides that
+    # by falling back to the full authentication exchange, but servers that
+    # verify the scramble eagerly (e.g. ProxySQL) reject it outright.
+    test "does not prepend the nonce like mysql_native_password does" do
+      sha = :crypto.hash(:sha256, "secret")
+
+      nonce_first =
+        :crypto.exor(sha, :crypto.hash(:sha256, @nonce <> :crypto.hash(:sha256, sha)))
+
+      refute Auth.caching_sha2_password("secret", @nonce) == nonce_first
+    end
+  end
+end


### PR DESCRIPTION
## The bug

`caching_sha2_password` reuses the `mysql_native_password` helper, so it prepends the nonce to the double-hashed password:

```elixir
def sha256_password(password, auth_plugin_data) do
  sha_hash(:sha256, password, auth_plugin_data)   # XOR(SHA256(pw), SHA256(nonce <> SHA256(SHA256(pw))))
end
```

[The caching_sha2_password exchange](https://dev.mysql.com/doc/dev/mysql-server/latest/page_caching_sha2_authentication_exchanges.html) appends it instead — `XOR(SHA256(pw), SHA256(SHA256(SHA256(pw)) <> nonce))`. The prepend ordering is correct for `mysql_native_password` (SHA1) only.

## Why it goes unnoticed against MySQL

MySQL answers a mismatching scramble with `perform_full_authentication` rather than an error, and the connection then succeeds via the public key exchange. So it works — but every connection pays for a full auth round trip that the cache was supposed to avoid, and `AuthMoreData(fast_auth_success)` is never exercised.

Servers that verify the scramble eagerly reject it outright. Against ProxySQL every connection fails:

```
** (MyXQL.Error) (1045) (ER_ACCESS_DENIED_ERROR) ProxySQL Error: Access denied for user 'xxx'@'10.68.xx.xxx' (using password: YES)
```

I confirmed this on the wire against ProxySQL 3306 (fronting Percona XtraDB Cluster 8.4.8) — identical connection, credentials and nonce, only the scramble ordering differing:

| scramble | server reply |
|---|---|
| `nonce <> SHA256(SHA256(pw))` (current) | `ERR 1045 Access denied` |
| `SHA256(SHA256(pw)) <> nonce` (this PR) | `AuthMoreData fast_auth_success` |

The same credentials authenticate fine with the `mysql` CLI from the same host, which is what makes this look like a credentials or allowlist problem rather than a driver one.

## Second half of the fix

Once the ordering is right, the server can actually reply `0x01 0x03` (fast auth success). That fell through to:

```elixir
def decode_auth_response(<<0x01, rest::binary>>), do: auth_more_data(data: rest)
```

so `<<3>>` was handed to `:public_key.pem_decode/1` as an RSA key and the connection crashed. This PR decodes it as `:fast_auth_success` and consumes the OK packet that trails it — necessary because `recv_packet/3` deliberately discards any packet following the one it decodes ("even if next packet follows, ignore it"), which would otherwise leave that OK in the socket and desync the next exchange. I verified both MySQL 8.4 and ProxySQL do send the trailing OK packet.

## Note on the public function

`sha256_password/2` is renamed to `caching_sha2_password/2`, since it only ever implemented the caching_sha2 scramble — the `sha256_password` plugin branch in `auth_response/3` sends cleartext or `<<1>>` and never calls it. Happy to keep a delegating `sha256_password/2` if you'd rather not touch the (moduledoc false) surface.

## Tests

- `test/myxql/protocol/auth_test.exs` — known-answer vectors for both plugins, plus a regression test asserting caching_sha2 does *not* match the prepended-nonce ordering.
- `caching_sha2_password (cached, fast auth)` in `client_test.exs` — connects twice so the second connection hits the server-side cache and exercises the `fast_auth_success` path, which previously crashed.

Full suite against MySQL 8.4.10: 222 tests, 0 failures (excluding two UNIX-socket tests that fail in my setup because the server runs in Docker — they fail identically on an unpatched checkout). 
